### PR TITLE
fix: Debian build compatibility - rename signal.h

### DIFF
--- a/include/lunet_signal.h
+++ b/include/lunet_signal.h
@@ -1,5 +1,5 @@
-#ifndef SIGNAL_H
-#define SIGNAL_H
+#ifndef LUNET_SIGNAL_H
+#define LUNET_SIGNAL_H
 
 #include <lua.h>
 

--- a/spec/json_spec.lua
+++ b/spec/json_spec.lua
@@ -48,7 +48,7 @@ describe("JSON Module", function()
   end)
   
   it("handles control characters", function()
-    local s = "\x01\x1f"
+    local s = "\001\031"
     local encoded = json.encode(s)
     assert.are.equal('"\\u0001\\u001f"', encoded)
   end)

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 
 #include "co.h"
 #include "fs.h"
+#include "lunet_signal.h"
 #include "mysql.h"
 #include "rt.h"
 #include "socket.h"

--- a/src/signal.c
+++ b/src/signal.c
@@ -1,9 +1,11 @@
-#include "signal.h"
+#include "lunet_signal.h"
 
 #include <lauxlib.h>
 #include <lua.h>
 #include <lualib.h>
+#include <signal.h>
 #include <stdlib.h>
+#include <string.h>
 #include <uv.h>
 
 #include "co.h"


### PR DESCRIPTION
Fixes Debian Trixie build issues caused by signal.h shadowing system header.