### PR TITLE
Realworld readme chinese

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -8,6 +8,13 @@
 
 [English Documentation](README.md)
 
+## RealWorld Conduit API 示例
+
+本仓库包含 RealWorld Conduit API（Medium.com 克隆）后端实现，示例文档见：
+
+- [README_realworld-CN.md](README_realworld-CN.md)
+- [README_realworld.md](README_realworld.md)
+
 ## 概述
 
 Lunet 是一个基于协程的网络库，提供同步风格的 API，底层异步执行。它结合了 C、LuaJIT 和 libuv 的强大功能，在保持代码清晰可读的同时提供高性能的 I/O 操作。

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A high-performance coroutine-based networking library for LuaJIT, built on top o
 
 This fork includes an implementation of the [RealWorld "Conduit"](https://github.com/gothinkster/realworld) API spec - a Medium.com clone demonstrating Lunet's capabilities as a web backend framework. The implementation covers users, profiles, articles, comments, tags, favorites, and follows endpoints. The app is located in the `app/` directory.
 
+Docs: [README_realworld.md](README_realworld.md) | [README_realworld-CN.md](README_realworld-CN.md)
+
 ### Demo Prerequisites
 
 - CMake 3.12+, LuaJIT 2.1+, libuv 1.x, libsodium, SQLite3, PostgreSQL (client libs)
@@ -50,7 +52,7 @@ cmake --build build
 .\build\Release\lunet.exe app\main.lua
 
 # Verify API is running
-curl http://127.0.0.1:8080/api/tags
+bin/test_curl.sh http://127.0.0.1:8080/api/tags
 ```
 # (Optional) Start a React/Vite frontend - clones to .tmp/conduit-vite
 make wui

--- a/README_realworld-CN.md
+++ b/README_realworld-CN.md
@@ -1,0 +1,90 @@
+# 基于 Lunet 的 RealWorld Conduit
+
+这是一个使用 **Lunet**（LuaJIT + libuv）实现的 [RealWorld Conduit API](https://realworld.io) 后端。
+
+[English Documentation](README_realworld.md)
+
+## 架构
+
+- **运行时**：Lunet（自研 C 核心 + LuaJIT + libuv）
+- **数据库**：MariaDB（运行于 Lima VM）
+- **加密**：libsodium（通过 FFI）
+- **JSON**：纯 Lua 实现
+
+## 前置条件
+
+1. **Lunet**：在本仓库中从源码构建（`build/lunet`）。
+2. **MariaDB**：运行在名为 `mariadb12` 的 Lima VM 实例中。
+3. **Libsodium**：`brew install libsodium`
+
+## 配置
+
+数据库配置位于 `app/db_config.lua`。
+默认连接 `127.0.0.1:3306`（由 Lima VM 端口转发到宿主机）。
+
+```lua
+return {
+    host = "127.0.0.1",
+    port = 3306,
+    user = "root",
+    password = "root",
+    database = "conduit",
+    charset = "utf8mb4"
+}
+```
+
+## 运行服务端与前端
+
+本项目包含一套完整的本地工作流：运行后端 API + RealWorld 前端（Vite React）。
+
+1.  **启动数据库（如尚未运行）：**
+    ```bash
+    limactl start mariadb12
+    ```
+
+2.  **构建 API：**
+    ```bash
+    make build
+    ```
+
+3.  **运行 API：**
+    ```bash
+    make run
+    ```
+    API 将监听在 `0.0.0.0:8080`。
+
+4.  **运行前端（WUI）：**
+    ```bash
+    make wui
+    ```
+    该命令会克隆 [React Vite RealWorld Example](https://github.com/romansndlr/react-vite-realworld-example-app)，将其配置为连接本地 API，并启动前端。
+    访问地址：**http://127.0.0.1:5173**
+
+5.  **停止全部服务：**
+    ```bash
+    make stop
+    ```
+    同时停止 API 与前端。
+
+## 测试
+
+### 调试服务器
+
+提供了一个自包含的调试服务器，用于验证完整链路（网络 + DB）：
+
+```bash
+./build/lunet app/debug_server.lua
+# 在另一个终端：
+curl -v --max-time 3 http://127.0.0.1:8090/
+```
+
+### API 测试
+
+你可以使用 RealWorld 仓库提供的 Postman/Newman 集合，或用简单命令进行验证。
+
+```bash
+# 创建用户
+bin/test_curl.sh -X POST http://127.0.0.1:8080/api/users \
+  -H "Content-Type: application/json" \
+  -d '{"user":{"username":"testuser","email":"test@example.com","password":"password"}}'
+```

--- a/README_realworld.md
+++ b/README_realworld.md
@@ -2,6 +2,8 @@
 
 This is a backend implementation of the [RealWorld Conduit API](https://realworld.io) using the **Lunet** framework (LuaJIT + libuv).
 
+[中文文档](README_realworld-CN.md)
+
 ## Architecture
 
 - **Runtime**: Lunet (custom C + LuaJIT + libuv)
@@ -71,7 +73,7 @@ A self-contained debug server is available to verify the full stack (Networking 
 ```bash
 ./build/lunet app/debug_server.lua
 # In another terminal:
-curl -v http://127.0.0.1:8090/
+curl -v --max-time 3 http://127.0.0.1:8090/
 ```
 
 ### API Tests
@@ -79,7 +81,7 @@ Use the Postman/Newman collection from the RealWorld repo or simple curl command
 
 ```bash
 # Create user
-curl -X POST http://127.0.0.1:8080/api/users \
+bin/test_curl.sh -X POST http://127.0.0.1:8080/api/users \
   -H "Content-Type: application/json" \
   -d '{"user":{"username":"testuser","email":"test@example.com","password":"password"}}'
 ```


### PR DESCRIPTION
Add a Chinese version of `README_realworld.md` and update READMEs for consistent bilingual navigation and safer curl examples.

The `README_realworld.md` was the only main README without a Chinese translation, despite the repository being bilingual. This PR addresses that by creating `README_realworld-CN.md` and adding cross-links in `README.md`, `README-CN.md`, and `README_realworld.md` to ensure users can easily switch between languages for the RealWorld documentation. Additionally, `curl` examples were updated to use `bin/test_curl.sh` for better reliability and to include a timeout for the debug server.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b2d2785-5c61-41b4-bc8b-c1de1dff0afe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b2d2785-5c61-41b4-bc8b-c1de1dff0afe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

