### PR TITLE
feat: Zero-cost coroutine reference tracing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,19 @@ project(lunet C)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# === Tracing Option ===
+# Enable with: cmake -DLUNET_TRACE=ON ..
+# This adds coroutine reference tracking for debugging.
+# When OFF, all tracing code is eliminated by the compiler (zero overhead).
+option(LUNET_TRACE "Enable coroutine reference tracing for debugging" OFF)
+
+if(LUNET_TRACE)
+  message(STATUS "LUNET_TRACE enabled - coroutine reference tracing active")
+  add_compile_definitions(LUNET_TRACE)
+else()
+  message(STATUS "LUNET_TRACE disabled - zero overhead release build")
+endif()
+
 include_directories(include)
 
 # === LuaJIT ===

--- a/include/co.h
+++ b/include/co.h
@@ -2,6 +2,16 @@
 #define CO_H
 
 #include <lua.h>
+
 int lunet_spawn(lua_State *L);
-int lunet_ensure_coroutine(lua_State *L, const char *func_name);
-#endif  // CO_H
+
+/*
+ * Internal: Do not call directly - use lunet_ensure_coroutine() instead.
+ * 
+ * This is the raw implementation that checks if we're in a yieldable coroutine.
+ * The safe wrapper lunet_ensure_coroutine() (defined in trace.h) adds stack
+ * integrity checking in debug builds.
+ */
+int _lunet_ensure_coroutine(lua_State *L, const char *func_name);
+
+#endif  /* CO_H */

--- a/include/trace.h
+++ b/include/trace.h
@@ -1,0 +1,193 @@
+#ifndef TRACE_H
+#define TRACE_H
+
+#include <lua.h>
+#include <lauxlib.h>
+#include "co.h"  /* For _lunet_ensure_coroutine */
+
+/*
+ * Coroutine Reference Tracing System
+ * ==================================
+ * 
+ * This module provides safe wrappers around low-level Lua-C operations that
+ * are prone to stack corruption bugs. In debug builds (LUNET_TRACE defined),
+ * these wrappers verify stack integrity and track coroutine reference lifetimes.
+ * In release builds, they compile to the minimal required code with zero overhead.
+ * 
+ * SAFE API (use these):
+ * ---------------------
+ *   lunet_ensure_coroutine(L, "func_name")  - Check we're in a yieldable coroutine
+ *   lunet_coref_create(L, &ref)             - Create a coroutine reference
+ *   lunet_coref_release(L, ref)             - Release a coroutine reference
+ * 
+ * INTERNAL API (do not use directly):
+ * -----------------------------------
+ *   _lunet_ensure_coroutine()  - Raw implementation without stack checking
+ * 
+ * LIFECYCLE:
+ * ----------
+ *   lunet_trace_init()            - Call once at startup
+ *   lunet_trace_dump()            - Print statistics
+ *   lunet_trace_assert_balanced() - Assert all refs released (call at shutdown)
+ */
+
+#ifdef LUNET_TRACE
+
+#include <stdio.h>
+#include <assert.h>
+
+/* Maximum tracked locations for debugging leaks */
+#define LUNET_TRACE_MAX_LOCATIONS 64
+
+typedef struct {
+  const char *file;
+  int line;
+  int count;  /* Positive = outstanding refs from this location */
+} lunet_trace_location_t;
+
+typedef struct {
+  /* Coroutine reference tracking */
+  int coref_balance;           /* +1 on create, -1 on release, must be 0 at end */
+  int coref_total_created;     /* Lifetime count of refs created */
+  int coref_total_released;    /* Lifetime count of refs released */
+  int coref_peak;              /* High water mark */
+  
+  /* Location tracking for debugging */
+  lunet_trace_location_t locations[LUNET_TRACE_MAX_LOCATIONS];
+  int location_count;
+  
+  /* Stack tracking */
+  int stack_checks_passed;
+  int stack_checks_failed;
+} lunet_trace_state_t;
+
+/* Global trace state - only exists when LUNET_TRACE defined */
+extern lunet_trace_state_t lunet_trace_state;
+
+/* Initialize tracing (call once at startup) */
+void lunet_trace_init(void);
+
+/* Dump current trace statistics */
+void lunet_trace_dump(void);
+
+/* Assert all refs are balanced (call at shutdown or checkpoints) */
+void lunet_trace_assert_balanced(const char *context);
+
+/* Internal tracking functions - called by macros */
+void lunet_trace_coref_add(const char *file, int line);
+void lunet_trace_coref_remove(const char *file, int line);
+void lunet_trace_stack_check(lua_State *L, int expected_base, int expected_delta,
+                              const char *file, int line);
+
+/*
+ * Stack depth checking - use at function entry/exit
+ */
+#define LUNET_STACK_ENTER(L) int _lunet_stack_base_##__LINE__ = lua_gettop(L)
+#define LUNET_STACK_EXIT(L, delta) \
+    lunet_trace_stack_check(L, _lunet_stack_base_##__LINE__, delta, __FILE__, __LINE__)
+
+/*
+ * lunet_ensure_coroutine - SAFE wrapper for _lunet_ensure_coroutine
+ * 
+ * Verifies we're in a yieldable coroutine AND checks stack integrity.
+ * On error, calls lua_error() and does not return.
+ * On success, returns normally (returns 0 but callers can ignore).
+ * 
+ * In trace builds: validates stack is not corrupted
+ * In release builds: just calls the underlying implementation
+ * 
+ * Usage (as a statement, no need to check return):
+ *   lunet_ensure_coroutine(L, "func_name");
+ *   // ... rest of function (only reached if in coroutine)
+ */
+#define lunet_ensure_coroutine(L, func_name) \
+    _lunet_ensure_coroutine_checked(L, func_name, __FILE__, __LINE__)
+
+static inline int _lunet_ensure_coroutine_checked(lua_State *L, const char *func_name,
+                                                   const char *file, int line) {
+    int stack_before = lua_gettop(L);
+    if (_lunet_ensure_coroutine(L, func_name) != 0) {
+        lua_error(L);  /* Does not return */
+    }
+    int stack_after = lua_gettop(L);
+    if (stack_after != stack_before) {
+        fprintf(stderr, "[TRACE] STACK BUG in %s at %s:%d: "
+                "_lunet_ensure_coroutine changed stack from %d to %d (delta=%d)\n",
+                func_name, file, line, stack_before, stack_after,
+                stack_after - stack_before);
+        lunet_trace_state.stack_checks_failed++;
+        assert(0 && "_lunet_ensure_coroutine corrupted stack");
+    }
+    return 0;
+}
+
+/*
+ * lunet_coref_create - SAFE coroutine reference creation
+ * 
+ * Creates a reference to the current coroutine in the Lua registry.
+ * Tracks creation for leak detection in trace builds.
+ * 
+ * Usage: lunet_coref_create(L, ctx->co_ref);
+ */
+#define lunet_coref_create(L, ref_var) do { \
+    lua_pushthread(L); \
+    (ref_var) = luaL_ref(L, LUA_REGISTRYINDEX); \
+    lunet_trace_coref_add(__FILE__, __LINE__); \
+} while(0)
+
+/*
+ * lunet_coref_release - SAFE coroutine reference release
+ * 
+ * Releases a coroutine reference from the Lua registry.
+ * Tracks release for leak detection in trace builds.
+ */
+#define lunet_coref_release(L, ref) do { \
+    luaL_unref(L, LUA_REGISTRYINDEX, ref); \
+    lunet_trace_coref_remove(__FILE__, __LINE__); \
+} while(0)
+
+#else /* !LUNET_TRACE */
+
+/*
+ * Zero-cost stubs - compiler eliminates these completely
+ */
+
+static inline void lunet_trace_init(void) {}
+static inline void lunet_trace_dump(void) {}
+static inline void lunet_trace_assert_balanced(const char *context) { (void)context; }
+
+/*
+ * lunet_ensure_coroutine - Direct call to implementation (no checking in release)
+ * On error, calls lua_error() and does not return.
+ */
+static inline int lunet_ensure_coroutine(lua_State *L, const char *func_name) {
+    if (_lunet_ensure_coroutine(L, func_name) != 0) {
+        lua_error(L);  /* Does not return */
+    }
+    return 0;
+}
+
+/*
+ * lunet_coref_create - Just the essential operations, no tracking
+ */
+#define lunet_coref_create(L, ref_var) do { \
+    lua_pushthread(L); \
+    (ref_var) = luaL_ref(L, LUA_REGISTRYINDEX); \
+} while(0)
+
+/*
+ * lunet_coref_release - Just the unref, no tracking
+ */
+#define lunet_coref_release(L, ref) do { \
+    luaL_unref(L, LUA_REGISTRYINDEX, ref); \
+} while(0)
+
+/*
+ * Stack checking - evaluates to nothing in release
+ */
+#define LUNET_STACK_ENTER(L) ((void)0)
+#define LUNET_STACK_EXIT(L, delta) ((void)0)
+
+#endif /* LUNET_TRACE */
+
+#endif /* TRACE_H */

--- a/src/co.c
+++ b/src/co.c
@@ -23,12 +23,13 @@ int lunet_spawn(lua_State *L) {
   return 0;
 }
 
-int lunet_ensure_coroutine(lua_State *L, const char *func_name) {
+int _lunet_ensure_coroutine(lua_State *L, const char *func_name) {
   if (lua_pushthread(L)) {
     lua_pop(L, 1);
     lua_pushfstring(L, "%s must be called from coroutine", func_name);
     return lua_error(L);
   }
+  lua_pop(L, 1);  // Pop the thread on success path
   if (!lua_isyieldable(L)) {
     lua_pushfstring(L, "%s called in non-yieldable context", func_name);
     return lua_error(L);

--- a/src/fs.c
+++ b/src/fs.c
@@ -7,6 +7,7 @@
 #include <uv.h>
 
 #include "co.h"
+#include "trace.h"
 
 typedef struct {
   uv_fs_t req;
@@ -20,7 +21,7 @@ static void lunet_fs_open_cb(uv_fs_t *req) {
 
   // resume coroutine
   lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->co_ref);
-  luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+  lunet_coref_release(L, ctx->co_ref);
 
   if (!lua_isthread(L, -1)) {
     lua_pop(L, 1);
@@ -102,9 +103,7 @@ static int fs_mode_to_flags(const char *mode, size_t mode_len) {
 }
 
 int lunet_fs_open(lua_State *L) {
-  if (lunet_ensure_coroutine(L, "fs.open") != 0) {
-    return lua_error(L);
-  }
+  lunet_ensure_coroutine(L, "fs.open");
   if (lua_gettop(L) < 2) {
     lua_pushnil(L);
     lua_pushstring(L, "fs.open requires path and mode");
@@ -129,13 +128,12 @@ int lunet_fs_open(lua_State *L) {
   }
 
   ctx->L = L;
-  lua_pushthread(L);
-  ctx->co_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+  lunet_coref_create(L, ctx->co_ref);
   ctx->req.data = ctx;
 
   int rc = uv_fs_open(uv_default_loop(), &ctx->req, path, flags, 0644, lunet_fs_open_cb);
   if (rc < 0) {
-    luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+    lunet_coref_release(L, ctx->co_ref);
     free(ctx);
     lua_pushnil(L);
     lua_pushstring(L, uv_strerror(rc));
@@ -157,7 +155,7 @@ static void lunet_fs_close_cb(uv_fs_t *req) {
 
   // resume coroutine
   lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->co_ref);
-  luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+  lunet_coref_release(L, ctx->co_ref);
 
   if (!lua_isthread(L, -1)) {
     lua_pop(L, 1);
@@ -182,9 +180,7 @@ cleanup:
 }
 
 int lunet_fs_close(lua_State *L) {
-  if (lunet_ensure_coroutine(L, "fs.close") != 0) {
-    return lua_error(L);
-  }
+  lunet_ensure_coroutine(L, "fs.close");
   if (lua_gettop(L) < 1 || !lua_isnumber(L, 1)) {
     lua_pushstring(L, "fs.close requires 1 integer fd");
     return 1;
@@ -199,13 +195,12 @@ int lunet_fs_close(lua_State *L) {
   }
 
   ctx->L = L;
-  lua_pushthread(L);
-  ctx->co_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+  lunet_coref_create(L, ctx->co_ref);
   ctx->req.data = ctx;
 
   int rc = uv_fs_close(uv_default_loop(), &ctx->req, fd, lunet_fs_close_cb);
   if (rc < 0) {
-    luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+    lunet_coref_release(L, ctx->co_ref);
     free(ctx);
     lua_pushstring(L, uv_strerror(rc));
     return 1;
@@ -225,7 +220,7 @@ static void lunet_fs_stat_cb(uv_fs_t *req) {
   lua_State *L = ctx->L;
 
   lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->co_ref);
-  luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+  lunet_coref_release(L, ctx->co_ref);
 
   if (!lua_isthread(L, -1)) {
     lua_pop(L, 1);
@@ -302,10 +297,7 @@ cleanup:
 }
 
 int lunet_fs_stat(lua_State *L) {
-  if (lunet_ensure_coroutine(L, "fs.fstat") != 0) {
-    return lua_error(L);
-  }
-
+  lunet_ensure_coroutine(L, "fs.stat");
   if (!lua_isstring(L, 1)) {
     lua_pushnil(L);
     lua_pushstring(L, "fs.fstat requires path");
@@ -322,13 +314,12 @@ int lunet_fs_stat(lua_State *L) {
   }
 
   ctx->L = L;
-  lua_pushthread(L);
-  ctx->co_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+  lunet_coref_create(L, ctx->co_ref);
   ctx->req.data = ctx;
 
   int rc = uv_fs_stat(uv_default_loop(), &ctx->req, path, lunet_fs_stat_cb);
   if (rc < 0) {
-    luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+    lunet_coref_release(L, ctx->co_ref);
     free(ctx);
     lua_pushnil(L);
     lua_pushstring(L, uv_strerror(rc));
@@ -351,7 +342,7 @@ static void lunet_fs_read_cb(uv_fs_t *req) {
   lua_State *L = ctx->L;
 
   lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->co_ref);
-  luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+  lunet_coref_release(L, ctx->co_ref);
 
   if (!lua_isthread(L, -1)) {
     lua_pop(L, 1);
@@ -378,9 +369,7 @@ cleanup:
   free(ctx);
 }
 int lunet_fs_read(lua_State *L) {
-  if (lunet_ensure_coroutine(L, "fs.read") != 0) {
-    return lua_error(L);
-  }
+  lunet_ensure_coroutine(L, "fs.read");
   if (lua_gettop(L) < 2 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
     lua_pushnil(L);
     lua_pushstring(L, "fs.read requires fd and length");
@@ -398,12 +387,11 @@ int lunet_fs_read(lua_State *L) {
   }
 
   ctx->L = L;
-  lua_pushthread(L);
-  ctx->co_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+  lunet_coref_create(L, ctx->co_ref);
   ctx->len = len;
   ctx->buf = malloc(len);
   if (!ctx->buf) {
-    luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+    lunet_coref_release(L, ctx->co_ref);
     free(ctx);
     lua_pushnil(L);
     lua_pushstring(L, "fs.read out of memory");
@@ -414,7 +402,7 @@ int lunet_fs_read(lua_State *L) {
   uv_buf_t buf = uv_buf_init(ctx->buf, len);
   int rc = uv_fs_read(uv_default_loop(), &ctx->req, fd, &buf, 1, 0, lunet_fs_read_cb);
   if (rc < 0) {
-    luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+    lunet_coref_release(L, ctx->co_ref);
     free(ctx->buf);
     free(ctx);
     lua_pushnil(L);
@@ -439,7 +427,7 @@ static void lunet_fs_write_cb(uv_fs_t *req) {
   lua_State *L = ctx->L;
 
   lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->co_ref);
-  luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+  lunet_coref_release(L, ctx->co_ref);
 
   if (!lua_isthread(L, -1)) {
     lua_pop(L, 1);
@@ -467,9 +455,7 @@ cleanup:
 }
 
 int lunet_fs_write(lua_State *L) {
-  if (lunet_ensure_coroutine(L, "fs.write") != 0) {
-    return lua_error(L);
-  }
+  lunet_ensure_coroutine(L, "fs.write");
   if (lua_gettop(L) < 2 || !lua_isnumber(L, 1) || !lua_isstring(L, 2)) {
     lua_pushnil(L);
     lua_pushstring(L, "fs.write requires fd and data");
@@ -487,12 +473,11 @@ int lunet_fs_write(lua_State *L) {
   }
 
   ctx->L = L;
-  lua_pushthread(L);
-  ctx->co_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+  lunet_coref_create(L, ctx->co_ref);
   ctx->len = len;
   ctx->buf = malloc(len);
   if (!ctx->buf) {
-    luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+    lunet_coref_release(L, ctx->co_ref);
     free(ctx);
     lua_pushnil(L);
     lua_pushstring(L, "fs.write out of memory");
@@ -505,7 +490,7 @@ int lunet_fs_write(lua_State *L) {
   uv_buf_t buf = uv_buf_init(ctx->buf, len);
   int rc = uv_fs_write(uv_default_loop(), &ctx->req, fd, &buf, 1, 0, lunet_fs_write_cb);
   if (rc < 0) {
-    luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+    lunet_coref_release(L, ctx->co_ref);
     free(ctx->buf);
     free(ctx);
     lua_pushnil(L);
@@ -548,7 +533,7 @@ static void lunet_fs_scandir_cb(uv_fs_t *req) {
   lua_State *L = ctx->L;
 
   lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->co_ref);
-  luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+  lunet_coref_release(L, ctx->co_ref);
 
   if (!lua_isthread(L, -1)) {
     lua_pop(L, 1);
@@ -587,9 +572,7 @@ cleanup:
 }
 
 int lunet_fs_scandir(lua_State *L) {
-  if (lunet_ensure_coroutine(L, "fs.scandir") != 0) {
-    return lua_error(L);
-  }
+  lunet_ensure_coroutine(L, "fs.scandir");
   if (lua_gettop(L) < 1 || !lua_isstring(L, 1)) {
     lua_pushnil(L);
     lua_pushstring(L, "fs.scandir requires path");
@@ -606,13 +589,12 @@ int lunet_fs_scandir(lua_State *L) {
   }
 
   ctx->L = L;
-  lua_pushthread(L);
-  ctx->co_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+  lunet_coref_create(L, ctx->co_ref);
   ctx->req.data = ctx;
 
   int rc = uv_fs_scandir(uv_default_loop(), &ctx->req, path, 0, lunet_fs_scandir_cb);
   if (rc < 0) {
-    luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+    lunet_coref_release(L, ctx->co_ref);
     free(ctx);
     lua_pushnil(L);
     lua_pushstring(L, uv_strerror(rc));

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,7 @@
 #include "rt.h"
 #include "socket.h"
 #include "timer.h"
+#include "trace.h"
 
 // register core module
 int lunet_open_core(lua_State *L) {
@@ -100,6 +101,9 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  /* Initialize tracing (no-op in release builds) */
+  lunet_trace_init();
+
   lua_State *L = luaL_newstate();
   luaL_openlibs(L);
   set_default_luaL(L);
@@ -115,6 +119,11 @@ int main(int argc, char **argv) {
   }
 
   int ret = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  
+  /* Dump trace statistics and assert balance (no-op in release builds) */
+  lunet_trace_dump();
+  lunet_trace_assert_balanced("shutdown");
+  
   lua_close(L);
   return ret;
 }

--- a/src/signal.c
+++ b/src/signal.c
@@ -7,6 +7,7 @@
 #include <uv.h>
 
 #include "co.h"
+#include "trace.h"
 
 typedef struct {
   uv_signal_t handle;
@@ -41,16 +42,13 @@ static void lunet_signal_cb(uv_signal_t *handle, int signo) {
   }
 
   // cleanup
-  luaL_unref(co, LUA_REGISTRYINDEX, ctx->co_ref);
+  lunet_coref_release(co, ctx->co_ref);
   uv_signal_stop(&ctx->handle);
   uv_close((uv_handle_t *)&ctx->handle, (uv_close_cb)free);
 }
 
 int lunet_signal_wait(lua_State *L) {
-  if (lunet_ensure_coroutine(L, "signal.wait") != 0) {
-    return lua_error(L);
-  }
-
+  lunet_ensure_coroutine(L, "signal.wait");
   const char *sig_name = luaL_checkstring(L, 1);
 
   // covert string to signal number
@@ -77,8 +75,7 @@ int lunet_signal_wait(lua_State *L) {
   }
 
   ctx->L = L;
-  lua_pushthread(L);
-  ctx->co_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+  lunet_coref_create(L, ctx->co_ref);
 
   uv_signal_init(uv_default_loop(), &ctx->handle);
   ctx->handle.data = ctx;

--- a/src/timer.c
+++ b/src/timer.c
@@ -6,6 +6,7 @@
 
 #include "co.h"
 #include "rt.h"
+#include "trace.h"
 
 typedef struct {
   uv_timer_t timer;
@@ -19,7 +20,7 @@ static void lunet_sleep_cb(uv_timer_t *timer) {
 
   // get coroutine reference from registry
   lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->co_ref);
-  luaL_unref(L, LUA_REGISTRYINDEX, ctx->co_ref);
+  lunet_coref_release(L, ctx->co_ref);
 
   if (lua_isthread(L, -1) == 0) {
     lua_pop(L, 1);  // pop invalid coroutine
@@ -41,10 +42,7 @@ static void lunet_sleep_cb(uv_timer_t *timer) {
 }
 // sleep for ms milliseconds
 int lunet_sleep(lua_State *co) {
-  if (lunet_ensure_coroutine(co, "lunet.sleep") != 0) {
-    return lua_error(co);
-  }
-
+  lunet_ensure_coroutine(co, "lunet.sleep");
   int ms = luaL_checkinteger(co, 1);
   if (ms < 0) {
     lua_pushstring(co, "lunet.sleep duration must be >= 0");
@@ -60,7 +58,12 @@ int lunet_sleep(lua_State *co) {
   ctx->L = default_luaL();
   lua_pushthread(co);
   lua_xmove(co, ctx->L, 1);
+  /* Note: Using raw luaL_ref here since we used lua_xmove, not LUNET_COREF_CREATE */
   ctx->co_ref = luaL_ref(ctx->L, LUA_REGISTRYINDEX);
+  /* But we still need to track it */
+#ifdef LUNET_TRACE
+  lunet_trace_coref_add(__FILE__, __LINE__);
+#endif
 
   // init timer
   uv_timer_init(uv_default_loop(), &ctx->timer);

--- a/src/trace.c
+++ b/src/trace.c
@@ -1,0 +1,174 @@
+/*
+ * Coroutine Reference Tracing Implementation
+ * 
+ * This file is only compiled when LUNET_TRACE is defined.
+ * It provides runtime tracking of coroutine references to detect leaks.
+ */
+
+#ifdef LUNET_TRACE
+
+#include "trace.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+/* Global trace state */
+lunet_trace_state_t lunet_trace_state;
+
+void lunet_trace_init(void) {
+  memset(&lunet_trace_state, 0, sizeof(lunet_trace_state));
+  fprintf(stderr, "[TRACE] Coroutine reference tracing initialized\n");
+}
+
+static int find_or_create_location(const char *file, int line) {
+  /* Search for existing location */
+  for (int i = 0; i < lunet_trace_state.location_count; i++) {
+    if (lunet_trace_state.locations[i].file == file &&
+        lunet_trace_state.locations[i].line == line) {
+      return i;
+    }
+  }
+  
+  /* Create new location if space available */
+  if (lunet_trace_state.location_count < LUNET_TRACE_MAX_LOCATIONS) {
+    int idx = lunet_trace_state.location_count++;
+    lunet_trace_state.locations[idx].file = file;
+    lunet_trace_state.locations[idx].line = line;
+    lunet_trace_state.locations[idx].count = 0;
+    return idx;
+  }
+  
+  /* Overflow - return -1 */
+  return -1;
+}
+
+void lunet_trace_coref_add(const char *file, int line) {
+  lunet_trace_state.coref_balance++;
+  lunet_trace_state.coref_total_created++;
+  
+  /* Track peak */
+  if (lunet_trace_state.coref_balance > lunet_trace_state.coref_peak) {
+    lunet_trace_state.coref_peak = lunet_trace_state.coref_balance;
+  }
+  
+  /* Track location */
+  int loc = find_or_create_location(file, line);
+  if (loc >= 0) {
+    lunet_trace_state.locations[loc].count++;
+  }
+  
+  fprintf(stderr, "[TRACE] COREF_ADD at %s:%d (balance=%d, total_created=%d)\n",
+          file, line, lunet_trace_state.coref_balance, 
+          lunet_trace_state.coref_total_created);
+}
+
+void lunet_trace_coref_remove(const char *file, int line) {
+  lunet_trace_state.coref_balance--;
+  lunet_trace_state.coref_total_released++;
+  
+  /* Track location */
+  int loc = find_or_create_location(file, line);
+  if (loc >= 0) {
+    lunet_trace_state.locations[loc].count--;
+  }
+  
+  fprintf(stderr, "[TRACE] COREF_RELEASE at %s:%d (balance=%d, total_released=%d)\n",
+          file, line, lunet_trace_state.coref_balance,
+          lunet_trace_state.coref_total_released);
+  
+  /* Warn on negative balance (double-release) */
+  if (lunet_trace_state.coref_balance < 0) {
+    fprintf(stderr, "[TRACE] WARNING: Negative coref balance! Possible double-release.\n");
+  }
+}
+
+void lunet_trace_stack_check(lua_State *L, int expected_base, int expected_delta,
+                              const char *file, int line) {
+  int actual_top = lua_gettop(L);
+  int expected_top = expected_base + expected_delta;
+  
+  if (actual_top != expected_top) {
+    fprintf(stderr, "[TRACE] STACK_CHECK FAILED at %s:%d: "
+            "expected top=%d (base=%d + delta=%d), actual=%d\n",
+            file, line, expected_top, expected_base, expected_delta, actual_top);
+    lunet_trace_state.stack_checks_failed++;
+    
+    /* Dump stack contents for debugging */
+    fprintf(stderr, "[TRACE] Stack contents:\n");
+    for (int i = 1; i <= actual_top; i++) {
+      int t = lua_type(L, i);
+      fprintf(stderr, "[TRACE]   [%d] %s", i, lua_typename(L, t));
+      if (t == LUA_TSTRING) {
+        fprintf(stderr, " = \"%s\"", lua_tostring(L, i));
+      } else if (t == LUA_TNUMBER) {
+        fprintf(stderr, " = %g", lua_tonumber(L, i));
+      } else if (t == LUA_TBOOLEAN) {
+        fprintf(stderr, " = %s", lua_toboolean(L, i) ? "true" : "false");
+      }
+      fprintf(stderr, "\n");
+    }
+    
+    assert(0 && "Stack check failed");
+  } else {
+    lunet_trace_state.stack_checks_passed++;
+  }
+}
+
+void lunet_trace_dump(void) {
+  fprintf(stderr, "\n");
+  fprintf(stderr, "========================================\n");
+  fprintf(stderr, "       LUNET TRACE SUMMARY\n");
+  fprintf(stderr, "========================================\n");
+  fprintf(stderr, "Coroutine References:\n");
+  fprintf(stderr, "  Total created:   %d\n", lunet_trace_state.coref_total_created);
+  fprintf(stderr, "  Total released:  %d\n", lunet_trace_state.coref_total_released);
+  fprintf(stderr, "  Current balance: %d\n", lunet_trace_state.coref_balance);
+  fprintf(stderr, "  Peak concurrent: %d\n", lunet_trace_state.coref_peak);
+  fprintf(stderr, "\n");
+  fprintf(stderr, "Stack Checks:\n");
+  fprintf(stderr, "  Passed: %d\n", lunet_trace_state.stack_checks_passed);
+  fprintf(stderr, "  Failed: %d\n", lunet_trace_state.stack_checks_failed);
+  fprintf(stderr, "\n");
+  
+  /* Show locations with outstanding refs (potential leaks) */
+  int leak_count = 0;
+  for (int i = 0; i < lunet_trace_state.location_count; i++) {
+    if (lunet_trace_state.locations[i].count != 0) {
+      if (leak_count == 0) {
+        fprintf(stderr, "Outstanding references by location:\n");
+      }
+      fprintf(stderr, "  %s:%d  count=%d\n",
+              lunet_trace_state.locations[i].file,
+              lunet_trace_state.locations[i].line,
+              lunet_trace_state.locations[i].count);
+      leak_count++;
+    }
+  }
+  
+  if (leak_count == 0 && lunet_trace_state.coref_balance == 0) {
+    fprintf(stderr, "All coroutine references properly balanced.\n");
+  }
+  
+  fprintf(stderr, "========================================\n\n");
+}
+
+void lunet_trace_assert_balanced(const char *context) {
+  if (lunet_trace_state.coref_balance != 0) {
+    fprintf(stderr, "[TRACE] ASSERTION FAILED at %s: coref_balance=%d (expected 0)\n",
+            context, lunet_trace_state.coref_balance);
+    lunet_trace_dump();
+    assert(lunet_trace_state.coref_balance == 0);
+  }
+  
+  if (lunet_trace_state.stack_checks_failed > 0) {
+    fprintf(stderr, "[TRACE] ASSERTION FAILED at %s: %d stack checks failed\n",
+            context, lunet_trace_state.stack_checks_failed);
+    assert(lunet_trace_state.stack_checks_failed == 0);
+  }
+  
+  fprintf(stderr, "[TRACE] Assertion passed at %s: all refs balanced\n", context);
+}
+
+#endif /* LUNET_TRACE */

--- a/test/run_trace_test.sh
+++ b/test/run_trace_test.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+#
+# Lunet Trace Test Runner
+#
+# This script:
+# 1. Finds an available high port
+# 2. Builds lunet with LUNET_TRACE enabled
+# 3. Runs the comprehensive trace test
+# 4. Verifies zero-cost abstraction in release build
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+BUILD_DIR="$PROJECT_DIR/build"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log() {
+	echo -e "${GREEN}[TEST]${NC} $1"
+}
+
+warn() {
+	echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+error() {
+	echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Find an available port
+find_available_port() {
+	local port=18080
+	while [ $port -lt 19000 ]; do
+		if ! lsof -i:$port >/dev/null 2>&1; then
+			echo $port
+			return
+		fi
+		port=$((port + 1))
+	done
+	echo "18080" # fallback
+}
+
+# Build with tracing enabled
+build_with_trace() {
+	log "Building with LUNET_TRACE=ON..."
+
+	mkdir -p "$BUILD_DIR/trace"
+	cd "$BUILD_DIR/trace"
+
+	cmake -DLUNET_TRACE=ON -DCMAKE_BUILD_TYPE=Debug "$PROJECT_DIR" 2>&1 | head -20
+	make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+
+	if [ ! -f "lunet" ]; then
+		error "Build failed - lunet binary not found"
+		exit 1
+	fi
+
+	log "Build successful: $BUILD_DIR/trace/lunet"
+}
+
+# Build release (no tracing)
+build_release() {
+	log "Building release (LUNET_TRACE=OFF)..."
+
+	mkdir -p "$BUILD_DIR/release"
+	cd "$BUILD_DIR/release"
+
+	cmake -DLUNET_TRACE=OFF -DCMAKE_BUILD_TYPE=Release "$PROJECT_DIR" 2>&1 | head -20
+	make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+
+	if [ ! -f "lunet" ]; then
+		error "Release build failed"
+		exit 1
+	fi
+
+	log "Release build successful: $BUILD_DIR/release/lunet"
+}
+
+# Run trace test
+run_trace_test() {
+	local port=$(find_available_port)
+	log "Running trace test on port $port..."
+
+	cd "$BUILD_DIR/trace"
+
+	export TEST_PORT=$port
+
+	if ./lunet "$SCRIPT_DIR/trace_test.lua" 2>&1; then
+		log "Trace test completed successfully!"
+		return 0
+	else
+		error "Trace test failed!"
+		return 1
+	fi
+}
+
+# Verify zero-cost abstraction
+verify_zero_cost() {
+	log "Verifying zero-cost abstraction..."
+
+	local trace_binary="$BUILD_DIR/trace/lunet"
+	local release_binary="$BUILD_DIR/release/lunet"
+
+	if [ ! -f "$trace_binary" ] || [ ! -f "$release_binary" ]; then
+		warn "Cannot compare binaries - one or both builds missing"
+		return
+	fi
+
+	local trace_size=$(stat -f%z "$trace_binary" 2>/dev/null || stat -c%s "$trace_binary" 2>/dev/null)
+	local release_size=$(stat -f%z "$release_binary" 2>/dev/null || stat -c%s "$release_binary" 2>/dev/null)
+
+	log "Binary sizes:"
+	log "  Trace build:   $trace_size bytes"
+	log "  Release build: $release_size bytes"
+
+	# Check if trace symbols are in release binary
+	if nm "$release_binary" 2>/dev/null | grep -q "lunet_trace"; then
+		warn "Trace symbols found in release binary - may not be zero-cost!"
+	else
+		log "No trace symbols in release binary - zero-cost verified!"
+	fi
+
+	# Check for trace function calls in disassembly
+	if command -v objdump >/dev/null 2>&1; then
+		if objdump -d "$release_binary" 2>/dev/null | grep -q "lunet_trace"; then
+			warn "Trace calls found in release disassembly"
+		else
+			log "No trace calls in release disassembly - zero-cost verified!"
+		fi
+	fi
+}
+
+# Main
+main() {
+	log "=========================================="
+	log "  LUNET TRACE TEST RUNNER"
+	log "=========================================="
+
+	# Build both versions
+	build_with_trace
+	build_release
+
+	echo ""
+	log "=========================================="
+	log "  RUNNING TRACE TEST"
+	log "=========================================="
+
+	if ! run_trace_test; then
+		error "Tests failed!"
+		exit 1
+	fi
+
+	echo ""
+	log "=========================================="
+	log "  VERIFYING ZERO-COST ABSTRACTION"
+	log "=========================================="
+
+	verify_zero_cost
+
+	echo ""
+	log "=========================================="
+	log "  ALL TESTS PASSED!"
+	log "=========================================="
+}
+
+main "$@"

--- a/test/simple_test.lua
+++ b/test/simple_test.lua
@@ -1,0 +1,53 @@
+-- Simple test to verify basic functionality
+local lunet = require("lunet")
+local fs = require("lunet.fs")
+
+print("[TEST] Starting simple trace test...")
+
+-- Test timer
+lunet.spawn(function()
+  print("[TEST] Timer: sleeping 100ms...")
+  lunet.sleep(100)
+  print("[TEST] Timer: done!")
+end)
+
+-- Test fs
+lunet.spawn(function()
+  local filename = "/tmp/lunet_simple_test.txt"
+  
+  -- Write
+  print("[TEST] FS: writing file...")
+  local fd, err = fs.open(filename, "w")
+  if err then error("open failed: " .. err) end
+  
+  local written, err = fs.write(fd, "Hello from lunet trace test!\n")
+  if err then error("write failed: " .. err) end
+  
+  err = fs.close(fd)
+  if err then error("close failed: " .. err) end
+  
+  -- Read
+  print("[TEST] FS: reading file...")
+  fd, err = fs.open(filename, "r")
+  if err then error("open failed: " .. err) end
+  
+  local data, err = fs.read(fd, 1024)
+  if err then error("read failed: " .. err) end
+  
+  err = fs.close(fd)
+  if err then error("close failed: " .. err) end
+  
+  print("[TEST] FS: read data: " .. data:gsub("\n", ""))
+  
+  -- Cleanup
+  os.remove(filename)
+  print("[TEST] FS: done!")
+end)
+
+-- Completion
+lunet.spawn(function()
+  lunet.sleep(200)
+  print("[TEST] All tests completed!")
+end)
+
+print("[TEST] Tests started, waiting...")

--- a/test/stack_bug_test.lua
+++ b/test/stack_bug_test.lua
@@ -1,0 +1,179 @@
+--[[
+  Stack Bug Detection Test
+  
+  This test specifically targets the lunet_ensure_coroutine() bug where
+  lua_pushthread() is called but the thread is not popped on success.
+  
+  The bug causes:
+  - Stack: [arg1, arg2] becomes [thread, arg1, arg2] after ensure_coroutine
+  - When code reads arg1 from position 1, it gets thread instead
+  - When code reads arg2 from position 2, it gets arg1 instead
+  
+  This test exercises functions that:
+  1. Call lunet_ensure_coroutine()
+  2. Then read arguments from specific stack positions
+  
+  With the bug present, fs.open("/path", "w") will:
+  - Read position 1 expecting path, get thread
+  - Read position 2 expecting mode, get "/path"
+  - Fail with "invalid mode" or similar error
+]]
+
+local lunet = require("lunet")
+local fs = require("lunet.fs")
+
+local function log(msg)
+  io.stderr:write(string.format("[BUG-TEST] %s\n", msg))
+end
+
+local function test_fs_open_args()
+  log("Testing fs.open argument reading...")
+  
+  -- This is the exact pattern that triggers the bug
+  -- fs.open calls lunet_ensure_coroutine(), then reads:
+  --   path = luaL_checkstring(L, 1)
+  --   mode = luaL_checkstring(L, 2)
+  --
+  -- With bug: stack is [thread, "/tmp/test.txt", "w"]
+  --   position 1 = thread (not a string!) -> error
+  --
+  -- Without bug: stack is ["/tmp/test.txt", "w"]
+  --   position 1 = path (correct)
+  --   position 2 = mode (correct)
+  
+  local path = "/tmp/stack_bug_test.txt"
+  local mode = "w"
+  
+  log(string.format("  Calling fs.open('%s', '%s')", path, mode))
+  
+  local fd, err = fs.open(path, mode)
+  
+  if err then
+    log(string.format("  ERROR: %s", err))
+    return false, err
+  end
+  
+  log(string.format("  Got fd: %s", tostring(fd)))
+  
+  -- If we got here, arguments were read correctly
+  fs.close(fd)
+  os.remove(path)
+  
+  return true, nil
+end
+
+local function test_sleep_args()
+  log("Testing lunet.sleep argument reading...")
+  
+  -- lunet.sleep calls lunet_ensure_coroutine(), then reads:
+  --   ms = luaL_checkinteger(co, 1)
+  --
+  -- With bug: stack is [thread, 100]
+  --   position 1 = thread (not an integer!) -> error
+  --
+  -- Without bug: stack is [100]
+  --   position 1 = 100 (correct)
+  
+  local ms = 50
+  log(string.format("  Calling lunet.sleep(%d)", ms))
+  
+  local start = os.clock()
+  lunet.sleep(ms)
+  local elapsed = (os.clock() - start) * 1000
+  
+  log(string.format("  Elapsed: %.1fms", elapsed))
+  
+  return true, nil
+end
+
+local function test_fs_write_args()
+  log("Testing fs.write argument reading...")
+  
+  -- First open a file
+  local path = "/tmp/stack_bug_write_test.txt"
+  local fd, err = fs.open(path, "w")
+  if err then
+    return false, "setup failed: " .. err
+  end
+  
+  -- fs.write calls lunet_ensure_coroutine(), then reads:
+  --   fd = lua_tointeger(L, 1)
+  --   data = luaL_checkstring(L, 2)
+  --
+  -- With bug: stack is [thread, fd, "data"]
+  --   position 1 = thread (will be 0 when converted to integer)
+  --   position 2 = fd (will try to write to wrong fd)
+  --
+  -- Without bug: stack is [fd, "data"]
+  --   position 1 = fd (correct)
+  --   position 2 = "data" (correct)
+  
+  local data = "Hello, World!"
+  log(string.format("  Calling fs.write(%s, '%s')", tostring(fd), data))
+  
+  local written, err = fs.write(fd, data)
+  
+  if err then
+    fs.close(fd)
+    os.remove(path)
+    return false, "write failed: " .. err
+  end
+  
+  log(string.format("  Wrote %s bytes", tostring(written)))
+  
+  fs.close(fd)
+  os.remove(path)
+  
+  return true, nil
+end
+
+-- Run all tests
+log("===========================================")
+log("  STACK BUG DETECTION TEST")
+log("===========================================")
+log("")
+log("This test checks if lunet_ensure_coroutine()")
+log("properly cleans up the Lua stack.")
+log("")
+
+local all_passed = true
+
+lunet.spawn(function()
+  local tests = {
+    {"fs.open args", test_fs_open_args},
+    {"lunet.sleep args", test_sleep_args},
+    {"fs.write args", test_fs_write_args},
+  }
+  
+  for _, test in ipairs(tests) do
+    local name, func = test[1], test[2]
+    log("")
+    log(string.format("--- Test: %s ---", name))
+    
+    local ok, err = pcall(function()
+      local success, msg = func()
+      if not success then
+        error(msg)
+      end
+    end)
+    
+    if ok then
+      log(string.format("PASSED: %s", name))
+    else
+      log(string.format("FAILED: %s - %s", name, tostring(err)))
+      all_passed = false
+    end
+  end
+  
+  log("")
+  log("===========================================")
+  if all_passed then
+    log("  ALL TESTS PASSED")
+    log("  Stack handling is correct!")
+  else
+    log("  TESTS FAILED")
+    log("  Bug detected: lunet_ensure_coroutine()")
+    log("  is leaving thread on stack!")
+  end
+  log("===========================================")
+end)

--- a/test/stack_pollution_test.lua
+++ b/test/stack_pollution_test.lua
@@ -1,0 +1,96 @@
+--[[
+  Stack Pollution Test
+  
+  This test proves that lunet_ensure_coroutine() bug causes
+  stack pollution by leaving threads on the stack.
+  
+  We can't directly inspect the C stack from Lua, but we can
+  observe the behavior:
+  
+  1. With the bug, each call to an async function leaves a thread on stack
+  2. This will eventually cause issues with stack overflow or memory
+  3. We can detect it by checking if operations that should not affect
+     the stack size actually change it
+  
+  The key insight: in a single coroutine, if we call multiple async
+  operations in sequence, the stack should remain clean between calls.
+  
+  With the bug:
+  - Call fs.open -> thread left on stack
+  - Call fs.close -> another thread left on stack
+  - Call fs.open -> another thread left on stack
+  - ... stack grows unbounded!
+]]
+
+local lunet = require("lunet")
+local fs = require("lunet.fs")
+
+local function log(msg)
+  io.stderr:write(string.format("[POLLUTION] %s\n", msg))
+end
+
+-- This test performs many sequential operations
+-- With the bug, each operation adds a thread to the stack
+-- Eventually this should cause visible problems
+
+local ITERATIONS = 1000
+
+log("===========================================")
+log("  STACK POLLUTION TEST")
+log("===========================================")
+log("")
+log(string.format("Running %d sequential async operations...", ITERATIONS * 4))
+log("With the bug, each operation leaks a thread onto the stack.")
+log("")
+
+local start_time = os.time()
+
+lunet.spawn(function()
+  for i = 1, ITERATIONS do
+    -- Each iteration does 4 async operations:
+    -- 1. fs.open
+    -- 2. fs.write  
+    -- 3. fs.close
+    -- 4. sleep
+    
+    local filename = "/tmp/pollution_test.txt"
+    
+    local fd, err = fs.open(filename, "w")
+    if err then
+      log(string.format("FAILED at iteration %d (open): %s", i, err))
+      return
+    end
+    
+    local written, err = fs.write(fd, "test")
+    if err then
+      fs.close(fd)
+      log(string.format("FAILED at iteration %d (write): %s", i, err))
+      return
+    end
+    
+    err = fs.close(fd)
+    if err then
+      log(string.format("FAILED at iteration %d (close): %s", i, err))
+      return
+    end
+    
+    lunet.sleep(1)
+    
+    if i % 100 == 0 then
+      log(string.format("Completed %d/%d iterations...", i, ITERATIONS))
+    end
+  end
+  
+  os.remove("/tmp/pollution_test.txt")
+  
+  local elapsed = os.time() - start_time
+  log("")
+  log("===========================================")
+  log(string.format("  COMPLETED %d iterations in %d seconds", ITERATIONS, elapsed))
+  log("===========================================")
+  log("")
+  log("If no errors occurred, the stack is being properly cleaned.")
+  log("Check the TRACE SUMMARY above:")
+  log("  - coref_balance should be 0")
+  log("  - Total created should equal total released")
+end)

--- a/test/stress_test.lua
+++ b/test/stress_test.lua
@@ -1,0 +1,200 @@
+--[[
+  Stress Test for Coroutine Reference Bug Detection
+  
+  This test exercises the lunet_ensure_coroutine() bug where a thread
+  is left on the Lua stack. The bug manifests when:
+  
+  1. lunet_ensure_coroutine() is called (pushes thread, doesn't pop on success)
+  2. Code tries to read arguments from expected stack positions
+  3. Arguments are off by 1 because of the extra thread on stack
+  
+  With the bug present, operations will either:
+  - Fail with wrong argument types
+  - Produce incorrect results
+  - Crash
+  
+  Run with:
+    cmake -DLUNET_TRACE=ON -DCMAKE_BUILD_TYPE=Debug ..
+    make
+    ./lunet test/stress_test.lua
+]]
+
+local lunet = require("lunet")
+local fs = require("lunet.fs")
+
+local ITERATIONS = 100
+local CONCURRENCY = 10
+
+local passed = 0
+local failed = 0
+local errors = {}
+
+local function log(msg)
+  io.stderr:write(string.format("[STRESS] %s\n", msg))
+end
+
+-- Test that exercises fs.open with specific arguments
+-- The bug will cause the path argument to be read from wrong position
+local function test_fs_open_close()
+  local filename = "/tmp/stress_test_" .. tostring(math.random(100000)) .. ".txt"
+  
+  -- This should work: fs.open(path, mode)
+  -- With the bug: stack has [thread, path, mode] instead of [path, mode]
+  -- So fs.open sees thread as path, path as mode
+  local fd, err = fs.open(filename, "w")
+  if err then
+    return false, "fs.open failed: " .. tostring(err)
+  end
+  
+  -- Write something
+  local written, err = fs.write(fd, "test data")
+  if err then
+    fs.close(fd)
+    return false, "fs.write failed: " .. tostring(err)
+  end
+  
+  -- Close
+  err = fs.close(fd)
+  if err then
+    return false, "fs.close failed: " .. tostring(err)
+  end
+  
+  -- Cleanup
+  os.remove(filename)
+  return true, nil
+end
+
+-- Test that exercises timer with specific duration
+-- The bug will cause duration to be read from wrong position
+local function test_sleep()
+  local start = os.clock()
+  lunet.sleep(10)  -- 10ms
+  local elapsed = (os.clock() - start) * 1000
+  
+  -- Should be roughly 10ms (allow for scheduling variance)
+  if elapsed < 0 or elapsed > 1000 then
+    return false, string.format("sleep timing wrong: expected ~10ms, got %.2fms", elapsed)
+  end
+  
+  return true, nil
+end
+
+-- Test rapid sequential operations
+-- This maximizes chances of hitting the stack corruption
+local function test_rapid_operations()
+  for i = 1, 10 do
+    lunet.sleep(1)
+    
+    local filename = "/tmp/rapid_test_" .. tostring(i) .. ".txt"
+    local fd, err = fs.open(filename, "w")
+    if err then
+      return false, "rapid open failed at iteration " .. i .. ": " .. tostring(err)
+    end
+    
+    local written, err = fs.write(fd, "iteration " .. i)
+    if err then
+      fs.close(fd)
+      return false, "rapid write failed at iteration " .. i .. ": " .. tostring(err)
+    end
+    
+    err = fs.close(fd)
+    if err then
+      return false, "rapid close failed at iteration " .. i .. ": " .. tostring(err)
+    end
+    
+    os.remove(filename)
+  end
+  
+  return true, nil
+end
+
+-- Run a single test iteration
+local function run_test(id, test_func, test_name)
+  lunet.spawn(function()
+    local ok, err = test_func()
+    if ok then
+      passed = passed + 1
+    else
+      failed = failed + 1
+      table.insert(errors, string.format("[%d] %s: %s", id, test_name, err))
+    end
+  end)
+end
+
+-- Main test driver
+log("===========================================")
+log("  STRESS TEST - Bug Detection")
+log("===========================================")
+log(string.format("Running %d iterations with %d concurrency", ITERATIONS, CONCURRENCY))
+log("")
+
+-- Launch concurrent test workers
+for i = 1, CONCURRENCY do
+  lunet.spawn(function()
+    for j = 1, ITERATIONS do
+      local test_id = (i - 1) * ITERATIONS + j
+      
+      -- Run different test types
+      if j % 3 == 0 then
+        run_test(test_id, test_fs_open_close, "fs_open_close")
+      elseif j % 3 == 1 then
+        run_test(test_id, test_sleep, "sleep")
+      else
+        run_test(test_id, test_rapid_operations, "rapid_ops")
+      end
+      
+      -- Small delay between iterations
+      lunet.sleep(5)
+    end
+  end)
+end
+
+-- Wait for completion and report
+lunet.spawn(function()
+  -- Wait for all tests to complete (with timeout)
+  local expected = ITERATIONS * CONCURRENCY
+  local max_wait = 60000  -- 60 seconds
+  local waited = 0
+  
+  while (passed + failed) < expected and waited < max_wait do
+    lunet.sleep(100)
+    waited = waited + 100
+    
+    if waited % 5000 == 0 then
+      log(string.format("Progress: %d/%d completed (%d passed, %d failed)", 
+                        passed + failed, expected, passed, failed))
+    end
+  end
+  
+  log("")
+  log("===========================================")
+  log("  STRESS TEST RESULTS")
+  log("===========================================")
+  log(string.format("Total tests: %d", passed + failed))
+  log(string.format("Passed:      %d", passed))
+  log(string.format("Failed:      %d", failed))
+  log("")
+  
+  if #errors > 0 then
+    log("Errors (first 10):")
+    for i = 1, math.min(10, #errors) do
+      log("  " .. errors[i])
+    end
+    if #errors > 10 then
+      log(string.format("  ... and %d more errors", #errors - 10))
+    end
+  end
+  
+  log("")
+  if failed > 0 then
+    log("STRESS TEST FAILED - Bug detected!")
+    log("")
+    log("Check trace output above for coref_balance != 0")
+  else
+    log("STRESS TEST PASSED")
+    log("")
+    log("Check trace output - coref_balance should be 0")
+  end
+end)
+
+log("Tests started...")

--- a/test/trace_test.lua
+++ b/test/trace_test.lua
@@ -1,0 +1,312 @@
+--[[
+  Comprehensive Trace Test
+  
+  This test exercises all code paths that use coroutine references:
+  - Timer (sleep)
+  - File system (open, read, write, close, stat, scandir)
+  - Socket (listen, accept, read, write, connect, close)
+  
+  Run with tracing enabled to verify all refs are properly balanced:
+    cmake -DLUNET_TRACE=ON -DCMAKE_BUILD_TYPE=Debug ..
+    make
+    ./lunet test/trace_test.lua
+  
+  At shutdown, trace should show:
+    - coref_balance = 0
+    - All refs balanced
+]]
+
+local lunet = require("lunet")
+local fs = require("lunet.fs")
+local socket = require("lunet.socket")
+
+-- Test configuration
+local TEST_PORT = tonumber(os.getenv("TEST_PORT")) or 18080
+local TEST_DIR = "/tmp/lunet_trace_test"
+local CONCURRENCY = 5
+local ITERATIONS = 3
+
+-- Utility functions
+local function log(msg)
+  io.stderr:write(string.format("[TEST] %s\n", msg))
+end
+
+local function assert_eq(actual, expected, msg)
+  if actual ~= expected then
+    error(string.format("%s: expected %s, got %s", msg or "assertion failed", tostring(expected), tostring(actual)))
+  end
+end
+
+-- Track completion of concurrent operations
+local completed = {
+  timers = 0,
+  fs_ops = 0,
+  socket_ops = 0,
+  clients = 0,
+}
+
+--------------------------------------------------------------------------------
+-- Timer Tests
+--------------------------------------------------------------------------------
+local function test_timers()
+  log("Starting timer tests...")
+  
+  for i = 1, CONCURRENCY do
+    lunet.spawn(function()
+      -- Multiple sleeps to exercise coref create/release cycle
+      lunet.sleep(10)
+      lunet.sleep(5)
+      lunet.sleep(1)
+      completed.timers = completed.timers + 1
+      log(string.format("Timer %d completed", i))
+    end)
+  end
+end
+
+--------------------------------------------------------------------------------
+-- File System Tests
+--------------------------------------------------------------------------------
+local function test_fs()
+  log("Starting FS tests...")
+  
+  -- Create test directory
+  os.execute("mkdir -p " .. TEST_DIR)
+  
+  for i = 1, CONCURRENCY do
+    lunet.spawn(function()
+      local filename = string.format("%s/test_%d.txt", TEST_DIR, i)
+      local content = string.format("Test content for file %d - iteration data\n", i)
+      
+      for iter = 1, ITERATIONS do
+        -- Open file for writing
+        local fd, err = fs.open(filename, "w")
+        if err then
+          error("fs.open write failed: " .. err)
+        end
+        
+        -- Write data
+        local written, err = fs.write(fd, content .. "iter=" .. iter .. "\n")
+        if err then
+          error("fs.write failed: " .. err)
+        end
+        
+        -- Close file
+        err = fs.close(fd)
+        if err then
+          error("fs.close failed: " .. err)
+        end
+        
+        -- Stat file
+        local stat, err = fs.stat(filename)
+        if err then
+          error("fs.stat failed: " .. err)
+        end
+        assert(stat.size > 0, "stat.size should be > 0")
+        
+        -- Open for reading
+        fd, err = fs.open(filename, "r")
+        if err then
+          error("fs.open read failed: " .. err)
+        end
+        
+        -- Read data
+        local data, err = fs.read(fd, 1024)
+        if err then
+          error("fs.read failed: " .. err)
+        end
+        assert(#data > 0, "read data should not be empty")
+        
+        -- Close file
+        err = fs.close(fd)
+        if err then
+          error("fs.close failed: " .. err)
+        end
+      end
+      
+      completed.fs_ops = completed.fs_ops + 1
+      log(string.format("FS worker %d completed (%d iterations)", i, ITERATIONS))
+    end)
+  end
+  
+  -- Test scandir
+  lunet.spawn(function()
+    lunet.sleep(100)  -- Wait for files to be created
+    
+    local entries, err = fs.scandir(TEST_DIR)
+    if err then
+      error("fs.scandir failed: " .. err)
+    end
+    
+    log(string.format("Scandir found %d entries", #entries))
+    for _, entry in ipairs(entries) do
+      log(string.format("  %s (%s)", entry.name, entry.type))
+    end
+    
+    completed.fs_ops = completed.fs_ops + 1
+  end)
+end
+
+--------------------------------------------------------------------------------
+-- Socket Tests
+--------------------------------------------------------------------------------
+local function test_sockets()
+  log("Starting socket tests...")
+  
+  -- Start server
+  lunet.spawn(function()
+    local server, err = socket.listen("tcp", "127.0.0.1", TEST_PORT)
+    if err then
+      error("socket.listen failed: " .. err)
+    end
+    
+    log(string.format("Server listening on port %d", TEST_PORT))
+    
+    -- Accept CONCURRENCY connections
+    for i = 1, CONCURRENCY do
+      local client, err = socket.accept(server)
+      if err then
+        error("socket.accept failed: " .. err)
+      end
+      
+      -- Handle client in separate coroutine
+      lunet.spawn(function()
+        local peer, err = socket.getpeername(client)
+        log(string.format("Accepted connection %d from %s", i, peer or "unknown"))
+        
+        -- Echo loop
+        for j = 1, ITERATIONS do
+          local data, err = socket.read(client)
+          if err then
+            log(string.format("Client %d read error: %s", i, err))
+            break
+          end
+          if not data then
+            log(string.format("Client %d disconnected", i))
+            break
+          end
+          
+          -- Echo back
+          err = socket.write(client, "ECHO:" .. data)
+          if err then
+            log(string.format("Client %d write error: %s", i, err))
+            break
+          end
+        end
+        
+        socket.close(client)
+        completed.socket_ops = completed.socket_ops + 1
+        log(string.format("Server handler %d completed", i))
+      end)
+    end
+    
+    -- Keep server open briefly then close
+    lunet.sleep(500)
+    socket.close(server)
+    log("Server closed")
+  end)
+  
+  -- Start clients after a brief delay
+  lunet.sleep(50)
+  
+  for i = 1, CONCURRENCY do
+    lunet.spawn(function()
+      local conn, err = socket.connect("127.0.0.1", TEST_PORT)
+      if err then
+        error(string.format("Client %d connect failed: %s", i, err))
+      end
+      
+      log(string.format("Client %d connected", i))
+      
+      for j = 1, ITERATIONS do
+        local msg = string.format("Hello from client %d, message %d", i, j)
+        
+        err = socket.write(conn, msg)
+        if err then
+          error(string.format("Client %d write failed: %s", i, err))
+        end
+        
+        local response, err = socket.read(conn)
+        if err then
+          error(string.format("Client %d read failed: %s", i, err))
+        end
+        
+        assert_eq(response, "ECHO:" .. msg, "Echo mismatch")
+      end
+      
+      socket.close(conn)
+      completed.clients = completed.clients + 1
+      log(string.format("Client %d completed", i))
+    end)
+  end
+end
+
+--------------------------------------------------------------------------------
+-- Main Test Runner
+--------------------------------------------------------------------------------
+log("===========================================")
+log("  LUNET TRACE TEST")
+log("===========================================")
+log(string.format("Configuration: PORT=%d, CONCURRENCY=%d, ITERATIONS=%d", 
+                  TEST_PORT, CONCURRENCY, ITERATIONS))
+log("")
+
+-- Run all tests
+test_timers()
+test_fs()
+test_sockets()
+
+-- Completion checker
+lunet.spawn(function()
+  local max_wait = 10000  -- 10 seconds
+  local waited = 0
+  local check_interval = 100
+  
+  while waited < max_wait do
+    lunet.sleep(check_interval)
+    waited = waited + check_interval
+    
+    -- Check if all tests completed
+    local all_done = 
+      completed.timers >= CONCURRENCY and
+      completed.fs_ops >= CONCURRENCY + 1 and  -- +1 for scandir
+      completed.socket_ops >= CONCURRENCY and
+      completed.clients >= CONCURRENCY
+    
+    if all_done then
+      break
+    end
+  end
+  
+  log("")
+  log("===========================================")
+  log("  TEST RESULTS")
+  log("===========================================")
+  log(string.format("Timers:     %d/%d", completed.timers, CONCURRENCY))
+  log(string.format("FS ops:     %d/%d", completed.fs_ops, CONCURRENCY + 1))
+  log(string.format("Socket ops: %d/%d", completed.socket_ops, CONCURRENCY))
+  log(string.format("Clients:    %d/%d", completed.clients, CONCURRENCY))
+  
+  local success = 
+    completed.timers >= CONCURRENCY and
+    completed.fs_ops >= CONCURRENCY + 1 and
+    completed.socket_ops >= CONCURRENCY and
+    completed.clients >= CONCURRENCY
+  
+  if success then
+    log("")
+    log("ALL TESTS PASSED!")
+    log("")
+    log("If LUNET_TRACE is enabled, check trace summary above for:")
+    log("  - coref_balance = 0")
+    log("  - All coroutine references properly balanced")
+  else
+    log("")
+    log("SOME TESTS FAILED!")
+    os.exit(1)
+  end
+  
+  -- Cleanup
+  os.execute("rm -rf " .. TEST_DIR)
+end)
+
+log("Tests started, waiting for completion...")


### PR DESCRIPTION
## Summary
- Adds `LUNET_TRACE` cmake option for debug builds
- Tracks coroutine reference create/release balance
- Detects stack pollution in `lunet_ensure_coroutine`
- Fixes stack pollution bug (closes #11)
- Zero overhead in release builds

## 概要
- 添加 `LUNET_TRACE` cmake 选项用于调试构建
- 跟踪协程引用的创建/释放平衡
- 检测 `lunet_ensure_coroutine` 中的堆栈污染
- 修复堆栈污染错误（关闭 #11）
- 发布版本零开销

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements an optional tracing layer for coroutine refs and stack safety, fixes a stack pollution bug, and updates subsystems to the new safe APIs.
> 
> - **Add** `LUNET_TRACE` CMake option and tracing module (`include/trace.h`, `src/trace.c`) with zero-cost stubs in release builds
> - **Fix** stack leak in `_lunet_ensure_coroutine` and wrap via `lunet_ensure_coroutine` with stack integrity checks (debug-only)
> - **Refactor** fs/socket/mysql/signal/timer to use `lunet_coref_create/release` and safe coroutine checks; initialize/dump/assert tracing in `main.c`
> - **Add tests/tools**: comprehensive Lua tests and `test/run_trace_test.sh` to validate tracing and zero-cost behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09a08a5a460fc72c8fc0d423fb9b3dd07dca62cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->