### PR TITLE
docs: note observed trace overhead

### DIFF
--- a/docs/XMAKE_INTEGRATION.md
+++ b/docs/XMAKE_INTEGRATION.md
@@ -96,3 +96,6 @@ Recommended CI profiles for downstream projects:
 
 This catches most lifecycle and coroutine bookkeeping failures early, while keeping production builds lean.
 
+Observed overhead (example data point): in a downstream stress test that brokered HTTP ingress over a unix socket to a DMZ broker and tunneled requests over an
+outbound TCP worker connection (request: `GET /api/tags`), a trace-enabled debug build ran at ~7.7% lower throughput than a non-instrumented release build
+under the same load. Treat this as an order-of-magnitude reference, not a guarantee; measure on your workload and deployment topology.


### PR DESCRIPTION
Single-file docs-only update: adds an observed data point from downstream stress testing that a trace-enabled debug build ran at ~7.7% lower throughput than a non-instrumented release build (workload: unix socket ingress to DMZ broker + outbound TCP tunnel to worker; request GET /api/tags).