### PR TITLE
Documentation badge guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,9 +361,8 @@ make stress  # Concurrent load test with tracing
 
 ## Downstream Integration
 
-For canonical downstream `xmake` integration (release/debug/trace/ASan profiles), see:
-
-- [`docs/XMAKE_INTEGRATION.md`](docs/XMAKE_INTEGRATION.md)
+- **[Integration guide](docs/XMAKE_INTEGRATION.md)** — Build Lunet and integrate it into your project (beginner-friendly)
+- **[Badge guide](docs/BADGES.md)** — Add badges (build status, Lunet version) to your project README
 
 ## License
 

--- a/docs/BADGES.md
+++ b/docs/BADGES.md
@@ -1,0 +1,63 @@
+# Badge Guide for Downstream Projects
+
+If your project uses Lunet, you can add badges to your README to show build status, Lunet version, and more. This guide provides ready-to-use Markdown snippets.
+
+## Lunet Version Badge
+
+Show which version of Lunet your project depends on:
+
+```markdown
+[![Lunet](https://img.shields.io/badge/Lunet-v0.1.0-blue?logo=lua)](https://github.com/lua-lunet/lunet)
+```
+
+Replace `v0.1.0` with your actual Lunet version. For the latest release, check [lunet releases](https://github.com/lua-lunet/lunet/releases).
+
+## Build Status Badge
+
+If your project has GitHub Actions that build or test with Lunet:
+
+```markdown
+[![Build](https://github.com/YOUR_ORG/YOUR_REPO/actions/workflows/build.yml/badge.svg)](https://github.com/YOUR_ORG/YOUR_REPO/actions/workflows/build.yml)
+```
+
+Replace `YOUR_ORG` and `YOUR_REPO` with your repository path. Adjust the workflow filename if yours differs (e.g. `ci.yml`, `test.yml`).
+
+## License Badge
+
+```markdown
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+```
+
+## Combined Example
+
+A typical README header for a Lunet-based project:
+
+```markdown
+# My Lunet App
+
+[![Build](https://github.com/lua-lunet/my-app/actions/workflows/build.yml/badge.svg)](https://github.com/lua-lunet/my-app/actions/workflows/build.yml)
+[![Lunet](https://img.shields.io/badge/Lunet-v0.1.0-blue?logo=lua)](https://github.com/lua-lunet/lunet)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A high-performance app built with [Lunet](https://github.com/lua-lunet/lunet).
+```
+
+## Customization
+
+- **Shields.io** supports many styles: `?style=flat`, `?style=flat-square`, `?style=for-the-badge`
+- **Color**: Append `?color=green` or use semantic colors like `success`, `important`, `informational`
+- **Logo**: Add `?logo=github` or `?logo=lua` for icon overlays
+
+Example with flat-square style:
+
+```markdown
+[![Lunet](https://img.shields.io/badge/Lunet-v0.1.0-blue?style=flat-square&logo=lua)](https://github.com/lua-lunet/lunet)
+```
+
+## Linking to Lunet
+
+Always link the badge to the Lunet repository so users can discover the library:
+
+```markdown
+[![Lunet](https://img.shields.io/badge/Lunet-v0.1.0-blue)](https://github.com/lua-lunet/lunet)
+```


### PR DESCRIPTION
Add badge documentation for downstream projects and replace the xmake integration guide with a beginner-friendly version.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-7765874d-6687-48ec-9c4e-427095eaf866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7765874d-6687-48ec-9c4e-427095eaf866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

