### PR TITLE
Db drivers lua_resume leak

### DIFF
--- a/ext/mysql/mysql.c
+++ b/ext/mysql/mysql.c
@@ -102,7 +102,7 @@ static void db_open_after_cb(uv_work_t* req, int status) {
     lua_pushnil(co);
     lua_pushstring(co, ctx->err);
   }
-  int rc = lua_resume(co, 2);
+  int rc = lunet_co_resume(co, 2);
   if (rc != 0 && rc != LUA_YIELD) {
     const char* err = lua_tostring(co, -1);
     if (err) fprintf(stderr, "lua_resume error in db.open: %s\n", err);
@@ -629,7 +629,7 @@ static void db_query_after_cb(uv_work_t* req, int status) {
   if (ctx->err[0] != '\0') {
     lua_pushnil(co);
     lua_pushstring(co, ctx->err);
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.query: %s\n", err);
@@ -671,7 +671,7 @@ static void db_query_after_cb(uv_work_t* req, int status) {
       }
       
       lua_pushnil(co);
-      int rc = lua_resume(co, 2);
+      int rc = lunet_co_resume(co, 2);
       if (rc != 0 && rc != LUA_YIELD) {
           const char* err = lua_tostring(co, -1);
           if (err) fprintf(stderr, "lua_resume error in db.query: %s\n", err);
@@ -883,7 +883,7 @@ static void db_exec_after_cb(uv_work_t* req, int status) {
   if (ctx->err[0] != '\0') {
     lua_pushnil(co);
     lua_pushstring(co, ctx->err);
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.exec: %s\n", err);
@@ -898,7 +898,7 @@ static void db_exec_after_cb(uv_work_t* req, int status) {
     lua_pushinteger(co, ctx->insert_id);
     lua_settable(co, -3);
     lua_pushnil(co);
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.exec: %s\n", err);

--- a/ext/postgres/postgres.c
+++ b/ext/postgres/postgres.c
@@ -202,7 +202,7 @@ static void db_open_after_cb(uv_work_t* req, int status) {
     lua_pushnil(co);
     lua_pushstring(co, ctx->err);
   }
-  int rc = lua_resume(co, 2);
+  int rc = lunet_co_resume(co, 2);
   if (rc != 0 && rc != LUA_YIELD) {
     const char* err = lua_tostring(co, -1);
     if (err) fprintf(stderr, "lua_resume error in db.open: %s\n", err);
@@ -433,7 +433,7 @@ static void db_query_after_cb(uv_work_t* req, int status) {
     ctx->result = NULL;
 
     lua_pushnil(co);
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.query: %s\n", err);
@@ -442,7 +442,7 @@ static void db_query_after_cb(uv_work_t* req, int status) {
   } else {
     lua_pushnil(co);
     lua_pushstring(co, ctx->err);
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.query: %s\n", err);
@@ -626,7 +626,7 @@ static void db_exec_after_cb(uv_work_t* req, int status) {
   if (ctx->err[0] != '\0') {
     lua_pushnil(co);
     lua_pushstring(co, ctx->err);
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.exec: %s\n", err);
@@ -641,7 +641,7 @@ static void db_exec_after_cb(uv_work_t* req, int status) {
     lua_pushinteger(co, ctx->insert_id);
     lua_settable(co, -3);
     lua_pushnil(co);
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.exec: %s\n", err);

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -236,7 +236,7 @@ static void db_open_after_cb(uv_work_t* req, int status) {
     lua_pushnil(co);
     lua_pushstring(co, ctx->err);
   }
-  int rc = lua_resume(co, 2);
+  int rc = lunet_co_resume(co, 2);
   if (rc != 0 && rc != LUA_YIELD) {
     const char* err = lua_tostring(co, -1);
     if (err) fprintf(stderr, "lua_resume error in db.open: %s\n", err);
@@ -481,7 +481,7 @@ static void db_query_after_cb(uv_work_t* req, int status) {
   if (ctx->err[0] != '\0') {
     lua_pushnil(co);
     lua_pushstring(co, ctx->err);
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.query: %s\n", err);
@@ -520,7 +520,7 @@ static void db_query_after_cb(uv_work_t* req, int status) {
 
   lua_pushnil(co);
   {
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.query: %s\n", err);
@@ -687,7 +687,7 @@ static void db_exec_after_cb(uv_work_t* req, int status) {
   if (ctx->err[0] != '\0') {
     lua_pushnil(co);
     lua_pushstring(co, ctx->err);
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.exec: %s\n", err);
@@ -702,7 +702,7 @@ static void db_exec_after_cb(uv_work_t* req, int status) {
     lua_pushinteger(co, ctx->insert_id);
     lua_settable(co, -3);
     lua_pushnil(co);
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.exec: %s\n", err);


### PR DESCRIPTION
Replace direct `lua_resume()` calls with `lunet_co_resume()` in DB drivers to prevent coroutine anchor memory leaks.

All three DB drivers were calling `lua_resume()` directly, bypassing the `lunet_co_resume()` wrapper which is responsible for unanchoring coroutines when they complete. This led to a memory leak in the anchor table as completed coroutines were never unanchored.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b903b704-97c5-4aab-8a88-1b6c1bf9c5c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b903b704-97c5-4aab-8a88-1b6c1bf9c5c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

