### PR TITLE
proposal: link DB extension modules against shared lunet core library

### DIFF
--- a/docs/XMAKE_INTEGRATION.md
+++ b/docs/XMAKE_INTEGRATION.md
@@ -35,10 +35,9 @@ xmake build
 - `-y` = accept defaults without prompting
 
 **Output files:**
-- `build/<platform>/<arch>/release/lunet.so` — the Lua module
-- `build/<platform>/<arch>/release/liblunet.dylib` (macOS) or `liblunet.so` (Linux) — the core shared library
-- `build/<platform>/<arch>/release/lunet-run` — standalone runner
-- `build/<platform>/<arch>/release/lunet/*.so` — driver modules (sqlite3, mysql, postgres)
+- `build/<platform>/<arch>/release/lunet.so` — the Lunet core shared library (also loadable via `require("lunet")`)
+- `build/<platform>/<arch>/release/lunet-run` — standalone runner (links against `lunet.so`)
+- `build/<platform>/<arch>/release/lunet/*.so` — driver modules (sqlite3, mysql, postgres) that link against `lunet.so`
 
 ### 2. Run your app with lunet-run
 

--- a/docs/XMAKE_INTEGRATION.md
+++ b/docs/XMAKE_INTEGRATION.md
@@ -36,7 +36,9 @@ xmake build
 
 **Output files:**
 - `build/<platform>/<arch>/release/lunet.so` — the Lua module
+- `build/<platform>/<arch>/release/liblunet.dylib` (macOS) or `liblunet.so` (Linux) — the core shared library
 - `build/<platform>/<arch>/release/lunet-run` — standalone runner
+- `build/<platform>/<arch>/release/lunet/*.so` — driver modules (sqlite3, mysql, postgres)
 
 ### 2. Run your app with lunet-run
 

--- a/ext/postgres/postgres.c
+++ b/ext/postgres/postgres.c
@@ -1,10 +1,9 @@
-#include "lunet_db_postgres.h"
-
 #include <libpq-fe.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "co.h"
+#include "rt.h"
 #include "trace.h"
 #include "uv.h"
 
@@ -202,7 +201,7 @@ static void db_open_after_cb(uv_work_t* req, int status) {
     lua_pushnil(co);
     lua_pushstring(co, ctx->err);
   }
-  int rc = lua_resume(co, 2);
+  int rc = lunet_co_resume(co, 2);
   if (rc != 0 && rc != LUA_YIELD) {
     const char* err = lua_tostring(co, -1);
     if (err) fprintf(stderr, "lua_resume error in db.open: %s\n", err);
@@ -433,7 +432,7 @@ static void db_query_after_cb(uv_work_t* req, int status) {
     ctx->result = NULL;
 
     lua_pushnil(co);
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.query: %s\n", err);
@@ -442,7 +441,7 @@ static void db_query_after_cb(uv_work_t* req, int status) {
   } else {
     lua_pushnil(co);
     lua_pushstring(co, ctx->err);
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.query: %s\n", err);
@@ -626,7 +625,7 @@ static void db_exec_after_cb(uv_work_t* req, int status) {
   if (ctx->err[0] != '\0') {
     lua_pushnil(co);
     lua_pushstring(co, ctx->err);
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.exec: %s\n", err);
@@ -641,7 +640,7 @@ static void db_exec_after_cb(uv_work_t* req, int status) {
     lua_pushinteger(co, ctx->insert_id);
     lua_settable(co, -3);
     lua_pushnil(co);
-    int rc = lua_resume(co, 2);
+    int rc = lunet_co_resume(co, 2);
     if (rc != 0 && rc != LUA_YIELD) {
       const char* err = lua_tostring(co, -1);
       if (err) fprintf(stderr, "lua_resume error in db.exec: %s\n", err);
@@ -881,4 +880,19 @@ int lunet_db_exec_params(lua_State* L) {
   }
 
   return lua_yield(L, 0);
+}
+
+LUNET_MODULE_API int luaopen_lunet_postgres(lua_State *L) {
+  lunet_init_core(L);
+  
+  luaL_Reg funcs[] = {{"open", lunet_db_open},
+                      {"close", lunet_db_close},
+                      {"query", lunet_db_query},
+                      {"exec", lunet_db_exec},
+                      {"escape", lunet_db_escape},
+                      {"query_params", lunet_db_query_params},
+                      {"exec_params", lunet_db_exec_params},
+                      {NULL, NULL}};
+  luaL_newlib(L, funcs);
+  return 1;
 }

--- a/include/co.h
+++ b/include/co.h
@@ -2,14 +2,15 @@
 #define CO_H
 
 #include "lunet_lua.h"
+#include "lunet_exports.h"
 
-int lunet_spawn(lua_State *L);
+LUNET_API int lunet_spawn(lua_State *L);
 
 /*
  * Unanchor a coroutine from the alive-set, allowing GC to collect it.
  * Call this after lua_resume returns LUA_OK or an error (coroutine is done).
  */
-void lunet_co_unanchor(lua_State *co);
+LUNET_API void lunet_co_unanchor(lua_State *co);
 
 /*
  * Resume a coroutine and automatically unanchor it if it finishes.
@@ -17,7 +18,7 @@ void lunet_co_unanchor(lua_State *co);
  * If the coroutine finishes (anything other than LUA_YIELD), it is
  * unanchored so GC can collect it.
  */
-int lunet_co_resume(lua_State *co, int nargs);
+LUNET_API int lunet_co_resume(lua_State *co, int nargs);
 
 /*
  * Internal: Do not call directly - use lunet_ensure_coroutine() instead.
@@ -26,6 +27,6 @@ int lunet_co_resume(lua_State *co, int nargs);
  * The safe wrapper lunet_ensure_coroutine() (defined in trace.h) adds stack
  * integrity checking in debug builds.
  */
-int _lunet_ensure_coroutine(lua_State *L, const char *func_name);
+LUNET_API int _lunet_ensure_coroutine(lua_State *L, const char *func_name);
 
 #endif  /* CO_H */

--- a/include/lunet_exports.h
+++ b/include/lunet_exports.h
@@ -8,13 +8,22 @@
 #define LUNET_EXPORTS_H
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-  #if defined(LUNET_BUILDING_DLL)
+  /* Core shared library exports (liblunet). */
+  #if defined(LUNET_BUILDING_CORE)
     #define LUNET_API __declspec(dllexport)
   #else
     #define LUNET_API
   #endif
+
+  /* Lua C module exports (lunet/sqlite3.dll, lunet/mysql.dll, ...). */
+  #if defined(LUNET_BUILDING_MODULE)
+    #define LUNET_MODULE_API __declspec(dllexport)
+  #else
+    #define LUNET_MODULE_API
+  #endif
 #else
   #define LUNET_API
+  #define LUNET_MODULE_API
 #endif
 
 #endif /* LUNET_EXPORTS_H */

--- a/include/rt.h
+++ b/include/rt.h
@@ -2,6 +2,10 @@
 #define RT_H
 
 #include "lunet_lua.h"
-void set_default_luaL(lua_State *L);
-lua_State *default_luaL(void);
+#include "lunet_exports.h"
+
+LUNET_API void set_default_luaL(lua_State *L);
+LUNET_API lua_State *default_luaL(void);
+LUNET_API void lunet_init_core(lua_State *L);
+
 #endif // RT_H

--- a/include/runtime.h
+++ b/include/runtime.h
@@ -1,11 +1,13 @@
 #ifndef RUNTIME_H
 #define RUNTIME_H
 
+#include "lunet_exports.h"
+
 // Global runtime configuration flags
 typedef struct {
     int dangerously_skip_loopback_restriction;
 } lunet_runtime_config_t;
 
-extern lunet_runtime_config_t g_lunet_config;
+extern LUNET_API lunet_runtime_config_t g_lunet_config;
 
 #endif // RUNTIME_H

--- a/include/trace.h
+++ b/include/trace.h
@@ -2,6 +2,7 @@
 #define TRACE_H
 
 #include "lunet_lua.h"
+#include "lunet_exports.h"
 #include "co.h"  /* For _lunet_ensure_coroutine */
 
 /*
@@ -66,22 +67,25 @@ typedef struct {
 } lunet_trace_state_t;
 
 /* Global trace state - only exists when LUNET_TRACE defined */
-extern lunet_trace_state_t lunet_trace_state;
+extern LUNET_API lunet_trace_state_t lunet_trace_state;
 
 /* Initialize tracing (call once at startup) */
-void lunet_trace_init(void);
+LUNET_API void lunet_trace_init(void);
 
 /* Dump current trace statistics */
-void lunet_trace_dump(void);
+LUNET_API void lunet_trace_dump(void);
 
 /* Assert all refs are balanced (call at shutdown or checkpoints) */
-void lunet_trace_assert_balanced(const char *context);
+LUNET_API void lunet_trace_assert_balanced(const char *context);
 
 /* Internal tracking functions - called by macros */
-void lunet_trace_coref_add(const char *file, int line, int ref);
-void lunet_trace_coref_remove(const char *file, int line, int ref);
-void lunet_trace_stack_check(lua_State *L, int expected_base, int expected_delta,
+LUNET_API void lunet_trace_coref_add(const char *file, int line, int ref);
+LUNET_API void lunet_trace_coref_remove(const char *file, int line, int ref);
+LUNET_API void lunet_trace_stack_check(lua_State *L, int expected_base, int expected_delta,
                               const char *file, int line);
+
+/* Get the current trace state */
+LUNET_API lunet_trace_state_t* lunet_get_trace_state(void);
 
 /*
  * Stack depth checking - use at function entry/exit

--- a/src/co.c
+++ b/src/co.c
@@ -1,4 +1,5 @@
 #include "co.h"
+#include "lunet_exports.h"
 
 #include <stdio.h>
 #include <assert.h>
@@ -54,7 +55,7 @@ static void lunet_co_anchor(lua_State *L) {
 }
 
 /* Release a coroutine anchor. co is the coroutine's lua_State. */
-void lunet_co_unanchor(lua_State *co) {
+LUNET_API void lunet_co_unanchor(lua_State *co) {
   lunet_co_get_anchor_table(co);    /* stack: anchortbl */
   lua_pushthread(co);               /* stack: anchortbl thread */
   lua_pushnil(co);                  /* stack: anchortbl thread nil */
@@ -62,7 +63,7 @@ void lunet_co_unanchor(lua_State *co) {
   lua_pop(co, 1);                   /* pop anchortbl */
 }
 
-int lunet_spawn(lua_State *L) {
+LUNET_API int lunet_spawn(lua_State *L) {
   luaL_checktype(L, 1, LUA_TFUNCTION);
   // create new coroutine
   lua_State *co = lua_newthread(L);
@@ -88,7 +89,7 @@ int lunet_spawn(lua_State *L) {
   return 0;
 }
 
-int lunet_co_resume(lua_State *co, int nargs) {
+LUNET_API int lunet_co_resume(lua_State *co, int nargs) {
 #ifdef LUNET_TRACE
   co_trace_resume_seq++;
 #endif
@@ -129,7 +130,7 @@ int lunet_co_resume(lua_State *co, int nargs) {
   return status;
 }
 
-int _lunet_ensure_coroutine(lua_State *L, const char *func_name) {
+LUNET_API int _lunet_ensure_coroutine(lua_State *L, const char *func_name) {
   if (lua_pushthread(L)) {
     lua_pop(L, 1);
     lua_pushfstring(L, "%s must be called from coroutine", func_name);

--- a/src/lunet_cli.c
+++ b/src/lunet_cli.c
@@ -1,0 +1,192 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#if !defined(_WIN32) && !defined(__CYGWIN__)
+#include <pthread.h>
+#endif
+#include <uv.h>
+
+#include "lunet_lua.h"
+#include "lunet_exports.h"
+#include "co.h"
+#include "fs.h"
+#include "lunet_signal.h"
+#include "rt.h"
+#include "socket.h"
+#include "timer.h"
+#include "udp.h"
+#include "trace.h"
+#include "runtime.h"
+#include "lunet_mem.h"
+#ifdef LUNET_PAXE
+#include "paxe.h"
+#endif
+
+static char *lunet_resolve_executable_path(const char *argv0) {
+#if defined(_WIN32)
+  return _fullpath(NULL, argv0, 0);
+#else
+  return realpath(argv0, NULL);
+#endif
+}
+
+/* Provided by the core lunet shared library. */
+LUNET_API int luaopen_lunet(lua_State *L);
+
+static void lunet_trace_shutdown(void) {
+#if defined(LUNET_TRACE) || defined(LUNET_EASY_MEMORY)
+    lunet_mem_summary();
+#endif
+#ifdef LUNET_TRACE
+    lunet_socket_trace_summary();
+    lunet_udp_trace_summary();
+    lunet_timer_trace_summary();
+    lunet_signal_trace_summary();
+    lunet_fs_trace_summary();
+    lunet_trace_dump();
+    lunet_trace_assert_balanced("shutdown");
+#endif
+#if defined(LUNET_TRACE) || defined(LUNET_EASY_MEMORY)
+    lunet_mem_assert_balanced("shutdown");
+#endif
+}
+
+#ifndef LUNET_NO_MAIN
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    fprintf(stderr, "Usage: %s [OPTIONS] <lua_file>\n", argv[0]);
+    fprintf(stderr, "\nOptions:\n");
+    fprintf(stderr, "  --dangerously-skip-loopback-restriction\n");
+    fprintf(stderr, "      Allow binding to any network interface. By default, binding is restricted\n");
+    fprintf(stderr, "      to loopback (127.0.0.1, ::1) or Unix sockets.\n");
+    fprintf(stderr, "  --verbose-trace\n");
+    fprintf(stderr, "      Enable verbose per-event tracing (debug builds only)\n");
+    return 1;
+  }
+
+  int script_index = 0;
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "--dangerously-skip-loopback-restriction") == 0) {
+      g_lunet_config.dangerously_skip_loopback_restriction = 1;
+      fprintf(stderr, "WARNING: Loopback restriction disabled. Binding to public interfaces allowed.\n");
+    } else if (strcmp(argv[i], "--verbose-trace") == 0) {
+      // Handled at compile time currently via LUNET_TRACE_VERBOSE
+      // Could be runtime flag in future
+    } else if (argv[i][0] == '-') {
+      fprintf(stderr, "Unknown option: %s\n", argv[i]);
+      return 1;
+    } else {
+      script_index = i;
+      break;
+    }
+  }
+
+  if (script_index == 0) {
+    fprintf(stderr, "Error: No script file specified.\n");
+    return 1;
+  }
+
+  lua_State *L = luaL_newstate();
+  luaL_openlibs(L);
+
+  /* Load core module and register lunet.* submodules into package.preload. */
+  luaopen_lunet(L);              /* stack: lunet */
+  lua_pushvalue(L, -1);          /* stack: lunet lunet */
+  lua_setglobal(L, "lunet");    /* stack: lunet */
+  lua_getglobal(L, "package");  /* stack: lunet package */
+  lua_getfield(L, -1, "loaded");/* stack: lunet package loaded */
+  lua_pushvalue(L, -3);          /* stack: lunet package loaded lunet */
+  lua_setfield(L, -2, "lunet"); /* package.loaded["lunet"] = lunet */
+  lua_pop(L, 3);                 /* pop loaded, package, lunet */
+
+  // Add binary's directory to cpath for finding driver .so files
+  // Drivers are in same dir as binary, named like sqlite3.so, mysql.so
+  // They're loaded as lunet.sqlite3, so we need lunet/?.so pattern
+  // Create symlink-style lookup: binarydir/lunet/?.so -> binarydir/?.so
+  {
+    char *exe_path = lunet_resolve_executable_path(argv[0]);
+    if (!exe_path) {
+      goto cpath_done;
+    }
+
+    char *last_slash = strrchr(exe_path, '/');
+    char *last_backslash = strrchr(exe_path, '\\');
+    char *last_sep = last_slash;
+    if (!last_sep || (last_backslash && last_backslash > last_sep)) {
+      last_sep = last_backslash;
+    }
+    if (!last_sep) {
+      free(exe_path);
+      goto cpath_done;
+    }
+
+    *last_sep = '\0';
+
+    lua_getglobal(L, "package");
+    lua_getfield(L, -1, "cpath");
+    const char *old_cpath = lua_tostring(L, -1);
+    lua_pop(L, 1);
+
+    char new_cpath[4096];
+#if defined(_WIN32)
+    snprintf(new_cpath, sizeof(new_cpath), "%s\\lunet\\?.dll;%s\\?.dll;%s",
+             exe_path, exe_path, old_cpath ? old_cpath : "");
+#else
+    snprintf(new_cpath, sizeof(new_cpath), "%s/lunet/?.so;%s/?.so;%s",
+             exe_path, exe_path, old_cpath ? old_cpath : "");
+#endif
+    lua_pushstring(L, new_cpath);
+    lua_setfield(L, -2, "cpath");
+    lua_pop(L, 1);
+
+    free(exe_path);
+  cpath_done:;
+  }
+
+  // run lua file
+  if (luaL_dofile(L, argv[script_index]) != LUA_OK) {
+    const char *error = lua_tostring(L, -1);
+    fprintf(stderr, "Error: %s\n", error);
+    lua_pop(L, 1);
+    lua_close(L);
+    return 1;
+  }
+
+  int ret = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  /* Optional: allow Lua script to control process exit status.
+   * Used by stress tests so we can exit without os.exit() (which skips trace shutdown).
+   */
+  int lua_exit_code = -1;
+  lua_getglobal(L, "__lunet_exit_code");
+  if (lua_isnumber(L, -1)) {
+    lua_exit_code = (int)lua_tointeger(L, -1);
+  }
+  lua_pop(L, 1);
+  
+  /* Dump trace statistics and assert balance */
+  lunet_trace_shutdown();
+  
+  lua_close(L);
+
+  {
+    int loop_close_status = uv_loop_close(uv_default_loop());
+    if (loop_close_status != 0) {
+      fprintf(stderr, "[LUNET] uv_loop_close failed at shutdown: %s\n",
+              uv_strerror(loop_close_status));
+    }
+#if UV_VERSION_HEX >= ((1 << 16) | (38 << 8) | 0)
+    if (loop_close_status == 0) {
+      uv_library_shutdown();
+    }
+#endif
+  }
+#if defined(LUNET_TRACE) || defined(LUNET_EASY_MEMORY)
+  lunet_mem_shutdown();
+#endif
+  if (lua_exit_code >= 0) {
+    return lua_exit_code;
+  }
+  return ret;
+}
+#endif

--- a/src/lunet_mem.c
+++ b/src/lunet_mem.c
@@ -38,7 +38,7 @@ void *lunet_mem_alloc_impl(size_t size, const char *file, int line) {
     return ptr;
 }
 
-void *lunet_mem_calloc_impl(size_t count, size_t size, const char *file, int line) {
+LUNET_API void *lunet_mem_calloc_impl(size_t count, size_t size, const char *file, int line) {
     size_t total = count * size;
     void *ptr = lunet_mem_alloc_impl(total, file, line);
     if (ptr) {
@@ -47,7 +47,7 @@ void *lunet_mem_calloc_impl(size_t count, size_t size, const char *file, int lin
     return ptr;
 }
 
-void *lunet_mem_realloc_impl(void *ptr, size_t size, const char *file, int line) {
+LUNET_API void *lunet_mem_realloc_impl(void *ptr, size_t size, const char *file, int line) {
     if (!ptr) {
         return lunet_mem_alloc_impl(size, file, line);
     }
@@ -122,7 +122,7 @@ void lunet_mem_free_impl(void *ptr, const char *file, int line) {
     free(header);
 }
 
-void lunet_mem_summary(void) {
+LUNET_API void lunet_mem_summary(void) {
     fprintf(stderr, "[MEM_TRACE] SUMMARY: allocs=%d frees=%d "
             "alloc_bytes=%lld free_bytes=%lld current=%lld peak=%lld\n",
             lunet_mem_state.alloc_count,
@@ -133,7 +133,7 @@ void lunet_mem_summary(void) {
             (long long)lunet_mem_state.peak_bytes);
 }
 
-void lunet_mem_assert_balanced(const char *context) {
+LUNET_API void lunet_mem_assert_balanced(const char *context) {
     if (lunet_mem_state.alloc_count != lunet_mem_state.free_count) {
         fprintf(stderr, "[MEM_TRACE] LEAK at %s: alloc_count=%d free_count=%d (delta=%d)\n",
                 context,

--- a/src/lunet_module.c
+++ b/src/lunet_module.c
@@ -1,0 +1,97 @@
+#include "lunet_lua.h"
+#include "lunet_exports.h"
+
+#include "co.h"
+#include "fs.h"
+#include "lunet_signal.h"
+#include "rt.h"
+#include "socket.h"
+#include "timer.h"
+#include "udp.h"
+
+static int lunet_open_core(lua_State *L) {
+  luaL_Reg funcs[] = {{"spawn", lunet_spawn}, {"sleep", lunet_sleep}, {NULL, NULL}};
+  luaL_newlib(L, funcs);
+  return 1;
+}
+
+static int lunet_open_socket(lua_State *L) {
+  luaL_Reg funcs[] = {{"listen", lunet_socket_listen},
+                      {"accept", lunet_socket_accept},
+                      {"getpeername", lunet_socket_getpeername},
+                      {"close", lunet_socket_close},
+                      {"read", lunet_socket_read},
+                      {"write", lunet_socket_write},
+                      {"connect", lunet_socket_connect},
+                      {"set_read_buffer_size", lunet_socket_set_read_buffer_size},
+                      {NULL, NULL}};
+  luaL_newlib(L, funcs);
+  return 1;
+}
+
+static int lunet_open_udp(lua_State *L) {
+  luaL_Reg funcs[] = {{"bind", lunet_udp_bind},
+                      {"send", lunet_udp_send},
+                      {"recv", lunet_udp_recv},
+                      {"close", lunet_udp_close},
+                      {NULL, NULL}};
+  luaL_newlib(L, funcs);
+  return 1;
+}
+
+static int lunet_open_signal(lua_State *L) {
+  luaL_Reg funcs[] = {{"wait", lunet_signal_wait}, {NULL, NULL}};
+  luaL_newlib(L, funcs);
+  return 1;
+}
+
+static int lunet_open_fs(lua_State *L) {
+  luaL_Reg funcs[] = {{"open", lunet_fs_open},
+                      {"close", lunet_fs_close},
+                      {"read", lunet_fs_read},
+                      {"write", lunet_fs_write},
+                      {"stat", lunet_fs_stat},
+                      {"scandir", lunet_fs_scandir},
+                      {NULL, NULL}};
+  luaL_newlib(L, funcs);
+  return 1;
+}
+
+static void lunet_open(lua_State *L) {
+  /* Register submodules into package.preload. */
+  lua_getglobal(L, "package");
+  lua_getfield(L, -1, "preload");
+  lua_pushcfunction(L, lunet_open_core);
+  lua_setfield(L, -2, "lunet");
+  lua_pop(L, 2);
+
+  lua_getglobal(L, "package");
+  lua_getfield(L, -1, "preload");
+  lua_pushcfunction(L, lunet_open_socket);
+  lua_setfield(L, -2, "lunet.socket");
+  lua_pop(L, 2);
+
+  lua_getglobal(L, "package");
+  lua_getfield(L, -1, "preload");
+  lua_pushcfunction(L, lunet_open_udp);
+  lua_setfield(L, -2, "lunet.udp");
+  lua_pop(L, 2);
+
+  lua_getglobal(L, "package");
+  lua_getfield(L, -1, "preload");
+  lua_pushcfunction(L, lunet_open_signal);
+  lua_setfield(L, -2, "lunet.signal");
+  lua_pop(L, 2);
+
+  lua_getglobal(L, "package");
+  lua_getfield(L, -1, "preload");
+  lua_pushcfunction(L, lunet_open_fs);
+  lua_setfield(L, -2, "lunet.fs");
+  lua_pop(L, 2);
+}
+
+LUNET_API int luaopen_lunet(lua_State *L) {
+  lunet_init_core(L);
+  lunet_open(L);
+  return lunet_open_core(L);
+}

--- a/src/paxe.c
+++ b/src/paxe.c
@@ -3,6 +3,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "lunet_mem.h"
+#include "lunet_exports.h"
+#include "rt.h"
 
 /* Constants */
 #define HEADER_LEN 8
@@ -583,4 +586,10 @@ int lunet_open_paxe(lua_State *L) {
     lua_setfield(L, -2, "VERSION");
 
     return 1;
+}
+
+LUNET_MODULE_API int luaopen_lunet_paxe(lua_State *L) {
+    lunet_init_core(L);
+    lua_newtable(L);
+    return lunet_open_paxe(L);
 }

--- a/src/rt.c
+++ b/src/rt.c
@@ -1,7 +1,21 @@
 #include "rt.h"
+#include "lunet_exports.h"
+#include "lunet_mem.h"
+#include "trace.h"
+#include <stddef.h>
 
 static lua_State *g_luaL = NULL;
 
-void set_default_luaL(lua_State *L) { g_luaL = L; }
+LUNET_API void set_default_luaL(lua_State *L) { g_luaL = L; }
 
-lua_State *default_luaL(void) { return g_luaL; }
+LUNET_API lua_State *default_luaL(void) { return g_luaL; }
+
+LUNET_API void lunet_init_core(lua_State *L) {
+    static int initialized = 0;
+    if (initialized) return;
+    initialized = 1;
+    
+    set_default_luaL(L);
+    lunet_mem_init();
+    lunet_trace_init();
+}

--- a/src/runtime_config.c
+++ b/src/runtime_config.c
@@ -1,0 +1,3 @@
+#include "runtime.h"
+
+LUNET_API lunet_runtime_config_t g_lunet_config = {0};

--- a/src/trace.c
+++ b/src/trace.c
@@ -8,6 +8,7 @@
 #ifdef LUNET_TRACE
 
 #include "trace.h"
+#include "lunet_exports.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,9 +16,13 @@
 #include <assert.h>
 
 /* Global trace state */
-lunet_trace_state_t lunet_trace_state;
+LUNET_API lunet_trace_state_t lunet_trace_state;
 
-void lunet_trace_init(void) {
+LUNET_API lunet_trace_state_t* lunet_get_trace_state(void) {
+    return &lunet_trace_state;
+}
+
+LUNET_API void lunet_trace_init(void) {
   memset(&lunet_trace_state, 0, sizeof(lunet_trace_state));
   /* Initialize ref_to_loc map to -1 (invalid) */
   for (int i = 0; i < LUNET_TRACE_MAX_REFS; i++) {
@@ -48,7 +53,7 @@ static int find_or_create_location(const char *file, int line) {
   return -1;
 }
 
-void lunet_trace_coref_add(const char *file, int line, int ref) {
+LUNET_API void lunet_trace_coref_add(const char *file, int line, int ref) {
   lunet_trace_state.coref_balance++;
   lunet_trace_state.coref_total_created++;
   
@@ -73,7 +78,7 @@ void lunet_trace_coref_add(const char *file, int line, int ref) {
           lunet_trace_state.coref_total_created);
 }
 
-void lunet_trace_coref_remove(const char *file, int line, int ref) {
+LUNET_API void lunet_trace_coref_remove(const char *file, int line, int ref) {
   lunet_trace_state.coref_balance--;
   lunet_trace_state.coref_total_released++;
   
@@ -139,7 +144,7 @@ void lunet_trace_stack_check(lua_State *L, int expected_base, int expected_delta
   }
 }
 
-void lunet_trace_dump(void) {
+LUNET_API void lunet_trace_dump(void) {
   fprintf(stderr, "\n");
   fprintf(stderr, "========================================\n");
   fprintf(stderr, "       LUNET TRACE SUMMARY\n");
@@ -177,7 +182,7 @@ void lunet_trace_dump(void) {
   fprintf(stderr, "========================================\n\n");
 }
 
-void lunet_trace_assert_balanced(const char *context) {
+LUNET_API void lunet_trace_assert_balanced(const char *context) {
   if (lunet_trace_state.coref_balance != 0) {
     fprintf(stderr, "[TRACE] ASSERTION FAILED at %s: coref_balance=%d (expected 0)\n",
             context, lunet_trace_state.coref_balance);


### PR DESCRIPTION
Refs: #76

This PR is an *experiment/proposal implementation* of linking DB extension modules against a shared Lunet core library so the driver modules can be more compact, while keeping normal `require(\"lunet.sqlite3\")` and query behavior.

What changed
- Build Lunet core once as `lunet.so` and link extension modules against it.
- DB extension outputs remain `build/.../lunet/*.so` and `require(\"lunet.sqlite3\")` continues to work.
- `lunet-run` now links against `lunet.so` instead of embedding all core sources.

Binary size impact (macOS arm64, xmake release)
Baseline: origin/main @ 4443ed2
Experiment: proposal/compact-db-modules @ bf3523a

| Artifact | Baseline | Experiment | Delta |
|---|---:|---:|---:|
| lunet/sqlite3.so | 77,000 | 38,424 | -38,576 (-50.1%) |
| lunet.so | 74,008 | 73,480 | -528 |
| lunet-run | 72,152 | 35,048 | -37,104 |

“Ship set” for sqlite3 usage
- Baseline: lunet.so + lunet/sqlite3.so = 151,008 bytes
- Experiment: lunet.so + lunet/sqlite3.so = 111,904 bytes (delta -39,104, -25.9%)

Validation (local)
- `./build/macosx/arm64/release/lunet-run test/smoke_sqlite3.lua` passes (queries + parameterized queries).

Outstanding / not for merge yet
- Cross-platform loader behavior needs CI validation (especially Windows driver DLL finding `lunet.dll` when loaded from `lunet/` subdir).
- Packaging/deployment story changes (thin drivers + shared core).
- Embedded script extraction bug is tracked separately in #79 (out-of-scope here).