### PR TITLE
Configuration error message

### DIFF
--- a/docs/XMAKE_INTEGRATION-CN.md
+++ b/docs/XMAKE_INTEGRATION-CN.md
@@ -81,6 +81,31 @@ export LUA_CPATH="$(pwd)/build/$(xmake l print(os.host()))/$(xmake l print(os.ar
 luajit -e 'local lunet=require("lunet"); print(type(lunet))'
 ```
 
+### 4. 将 Lunet 作为 xmake 子项目使用
+
+如果您的应用有自己的 `xmake.lua`，可以把 Lunet 作为子项目引入，并通过
+`add_deps("lunet")` 链接：
+
+```lua
+set_project("myapp")
+set_languages("c99")
+add_rules("mode.debug", "mode.release")
+
+includes("lunet")
+
+add_requires("pkgconfig::luajit", "pkgconfig::libuv")
+
+target("myapp")
+    set_kind("binary")
+    add_files("src/*.c")
+    add_deps("lunet")
+    add_packages("luajit", "libuv")
+target_end()
+```
+
+Lunet 会继续输出用于 Lua `require` 的 `lunet.so`，并额外生成兼容链接用的
+`liblunet.so`（适配通过 `-l<name>` 进行依赖链接的工具链）。
+
 ---
 
 ## 构建配置（各场景使用指南）

--- a/docs/XMAKE_INTEGRATION.md
+++ b/docs/XMAKE_INTEGRATION.md
@@ -81,6 +81,31 @@ export LUA_CPATH="$(pwd)/build/$(xmake l print(os.host()))/$(xmake l print(os.ar
 luajit -e 'local lunet=require("lunet"); print(type(lunet))'
 ```
 
+### 4. Use Lunet as an xmake subproject
+
+If your app has its own `xmake.lua`, include Lunet as a subproject and link it
+with `add_deps("lunet")`:
+
+```lua
+set_project("myapp")
+set_languages("c99")
+add_rules("mode.debug", "mode.release")
+
+includes("lunet")
+
+add_requires("pkgconfig::luajit", "pkgconfig::libuv")
+
+target("myapp")
+    set_kind("binary")
+    add_files("src/*.c")
+    add_deps("lunet")
+    add_packages("luajit", "libuv")
+target_end()
+```
+
+Lunet keeps the Lua module output as `lunet.so` and also emits a compatibility
+`liblunet.so` for toolchains that link dependencies via `-l<name>`.
+
 ---
 
 ## Build Profiles (When to Use Each)


### PR DESCRIPTION
Fix `add_deps("lunet")` linking for subprojects and update documentation.

The `lunet` target produced `lunet.so` but `add_deps("lunet")` expected `liblunet.so`, causing linker errors (issue #92). This PR adds a `liblunet.so` compatibility artifact and corrects a subproject lint rule path.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e861cbf1-60c8-4bf6-a299-e322ebda9717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e861cbf1-60c8-4bf6-a299-e322ebda9717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

