### PR TITLE
fix(httpc): add Windows syslinks for Schannel TLS and zlib

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -587,7 +587,10 @@ target("lunet-httpc")
     if is_plat("windows") then
         add_cflags("/TC")
         add_defines("LUNET_BUILDING_DLL")
-        add_syslinks("ws2_32", "iphlpapi", "userenv", "psapi", "advapi32", "user32", "shell32", "ole32", "dbghelp")
+        -- libcurl on Windows (vcpkg/Schannel) needs crypto, security, and zlib libs
+        add_syslinks("ws2_32", "iphlpapi", "userenv", "psapi", "advapi32", "user32", "shell32", "ole32", "dbghelp",
+                     "crypt32", "secur32")
+        add_packages("zlib")
     end
     if has_config("lunet_trace") then
         add_defines("LUNET_TRACE")


### PR DESCRIPTION
## Fix

Add missing Windows system libraries to the `lunet-httpc` xmake target.

vcpkg's libcurl on Windows uses Schannel for TLS and links against zlib for content encoding. The linker fails with 24 unresolved externals without these:

- `crypt32` - certificate store APIs (CertOpenStore, CertFreeCertificateContext, etc.)
- `secur32` - SSPI (InitSecurityInterfaceW)
- `zlib` package - inflate/deflate (via vcpkg transitive dep)

## Evidence

CI log from lua-lunet/lunet-mcp-sse PR #5, "Build Windows amd64" job:
```
libcurl.lib(content_encoding.c.obj) : error LNK2019: unresolved external symbol inflate
libcurl.lib(schannel.c.obj) : error LNK2019: unresolved external symbol __imp_CertOpenStore
...
httpc.dll : fatal error LNK1120: 24 unresolved externals
```

## Verification

Linux/macOS unaffected (no change to their link flags). Windows CI should now link successfully.
