### PR TITLE
Issue 86 status check

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -327,7 +327,7 @@ target("lunet-bin")
         add_includedirs(".tmp/generated")
 
         before_build(function ()
-            local root = os.projectdir()
+            local root = os.scriptdir()
             local generator = path.join(root, "bin", "generate_embed_scripts.lua")
             local source_dir = get_config("lunet_embed_scripts_dir") or "lua"
             local generated_dir = path.join(root, ".tmp", "generated")


### PR DESCRIPTION
Fix subproject path resolution for embed script generation by using `os.scriptdir()` instead of `os.projectdir()`.

This change resolves the remaining part of issue #86, where `os.projectdir()` incorrectly resolved paths for Lunet's internal tooling when Lunet was included as a subproject, leading to build failures.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-ee062131-16b1-4a7b-905e-cc6051fc8e9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee062131-16b1-4a7b-905e-cc6051fc8e9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

