### PR TITLE
Easymem release build cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -433,34 +433,6 @@ jobs:
           exit $LASTEXITCODE
         }
 
-    - name: Configure EasyMem experimental release (Unix)
-      if: runner.os != 'Windows'
-      run: xmake f -c -m release --lunet_trace=n --lunet_verbose_trace=n --easy_memory_experimental=y --easy_memory_arena_mb=128 -y
-
-    - name: Configure EasyMem experimental release (Windows)
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        $env:VCPKG_ROOT = "${{ github.workspace }}/vcpkg"
-        $env:VCPKG_DEFAULT_TRIPLET = "x64-windows"
-        $env:CL = "/MP"
-        $env:CI = "true"
-        xmake f -c -m release --lunet_trace=n --lunet_verbose_trace=n --easy_memory_experimental=y --easy_memory_arena_mb=128 -y
-
-    - name: Build Core + DB Drivers (EasyMem experimental, Unix)
-      if: runner.os != 'Windows'
-      run: |
-        xmake build lunet-bin
-        xmake build lunet-sqlite3
-        xmake build lunet-mysql
-        xmake build lunet-postgres
-
-    - name: Build Core + SQLite Driver (EasyMem experimental, Windows)
-      if: runner.os == 'Windows'
-      run: |
-        xmake build lunet-bin
-        xmake build lunet-sqlite3
-
   publish-release:
     name: Publish release
     if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.ref, 'v'))

--- a/README-CN.md
+++ b/README-CN.md
@@ -45,6 +45,8 @@ xmake build-release
 xmake build-debug
 ```
 
+发布档位默认会剥离 EasyMem。若需 EasyMem 诊断，请使用 debug/ASan 档位。
+
 ## 示例应用
 
 完整的 RealWorld "Conduit" API 实现请参见 [lunet-realworld-example-app](https://github.com/lua-lunet/lunet-realworld-example-app)。

--- a/README.md
+++ b/README.md
@@ -47,14 +47,7 @@ xmake build-release
 xmake build-debug
 ```
 
-### Experimental release with EasyMem
-
-```bash
-xmake f -c -m release --lunet_trace=n --lunet_verbose_trace=n --easy_memory_experimental=y --easy_memory_arena_mb=128 -y
-xmake build
-```
-
-`easy_memory_experimental` is opt-in and intended for diagnostics-heavy release experiments.
+Release profiles strip EasyMem by default. Use debug/ASan profiles for EasyMem diagnostics.
 
 ## Example: MCP-SSE Server
 

--- a/docs/WORKFLOW-CN.md
+++ b/docs/WORKFLOW-CN.md
@@ -41,7 +41,6 @@
 |------|------|
 | `xmake build-release` | 配置并构建优化的发布档位 |
 | `xmake build-debug` | 配置并构建启用 `LUNET_TRACE` 的调试档位 |
-| `xmake build-easy-memory-experimental` | 配置并构建 EasyMem 实验性发布档位 |
 
 ### 功能测试
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -41,7 +41,6 @@ Every task below is defined in `xmake.lua` and can be run with `xmake <task>`.
 |------|-------------|
 | `xmake build-release` | Configure and build optimized release profile |
 | `xmake build-debug` | Configure and build debug profile with `LUNET_TRACE` |
-| `xmake build-easy-memory-experimental` | Configure and build EasyMem experimental release profile |
 
 ### Functional Tests
 

--- a/docs/XMAKE_INTEGRATION-CN.md
+++ b/docs/XMAKE_INTEGRATION-CN.md
@@ -116,7 +116,6 @@ Lunet 会继续输出用于 Lua `require` 的 `lunet.so`，并额外生成兼容
 | **调试 + 追踪** | 开发环境，捕获 bug | `xmake f -c -m debug --lunet_trace=y --lunet_verbose_trace=n -y` |
 | **详细追踪** | 详细调试，记录每个事件 | `xmake f -c -m debug --lunet_trace=y --lunet_verbose_trace=y -y` |
 | **ASan + EasyMem** | 内存 bug（ASan + 分配器完整性诊断） | `xmake f -c -m debug --lunet_trace=y --asan=y -y` |
-| **实验性 EasyMem 发布版** | 带分配器诊断的发布二进制 | `xmake f -c -m release --lunet_trace=n --lunet_verbose_trace=n --easy_memory_experimental=y --easy_memory_arena_mb=128 -y` |
 
 **提示：** 切换配置时使用 `-c` 强制重新配置。
 
@@ -164,21 +163,14 @@ Lunet 支持 [EasyMem/easy_memory](https://github.com/EasyMem/easy_memory) 作�
 
 ### 手动选择启用
 
-在不启用追踪的情况下显式启用 EasyMem：
+在不启用追踪的开发档位下显式启用 EasyMem：
 
 ```bash
-xmake f -c -m release --lunet_trace=n --lunet_verbose_trace=n --easy_memory=y -y
+xmake f -c -m debug --lunet_trace=n --lunet_verbose_trace=n --easy_memory=y -y
 xmake build
 ```
 
-### 实验性发布模式
-
-在发布版中启用完整诊断用于分配器分析：
-
-```bash
-xmake f -c -m release --lunet_trace=n --lunet_verbose_trace=n --easy_memory_experimental=y --easy_memory_arena_mb=128 -y
-xmake build
-```
+发布档位应默认保持 EasyMem 被剥离。
 
 ### 内存区大小调整
 

--- a/docs/XMAKE_INTEGRATION.md
+++ b/docs/XMAKE_INTEGRATION.md
@@ -116,7 +116,6 @@ Lunet keeps the Lua module output as `lunet.so` and also emits a compatibility
 | **Debug + trace** | Development, catches bugs | `xmake f -c -m debug --lunet_trace=y --lunet_verbose_trace=n -y` |
 | **Verbose trace** | Detailed debugging, logs every event | `xmake f -c -m debug --lunet_trace=y --lunet_verbose_trace=y -y` |
 | **ASan + EasyMem** | Memory bugs (ASan + allocator integrity diagnostics) | `xmake f -c -m debug --lunet_trace=y --asan=y -y` |
-| **Experimental EasyMem Release** | Release binary with allocator diagnostics | `xmake f -c -m release --lunet_trace=n --lunet_verbose_trace=n --easy_memory_experimental=y --easy_memory_arena_mb=128 -y` |
 
 **Tip:** Use `-c` to force a clean reconfigure when switching profiles.
 
@@ -164,21 +163,14 @@ EasyMem is enabled automatically when either of these is enabled:
 
 ### Manual opt-in
 
-Enable EasyMem explicitly without enabling trace:
+Enable EasyMem explicitly in a development profile without enabling trace:
 
 ```bash
-xmake f -c -m release --lunet_trace=n --lunet_verbose_trace=n --easy_memory=y -y
+xmake f -c -m debug --lunet_trace=n --lunet_verbose_trace=n --easy_memory=y -y
 xmake build
 ```
 
-### Experimental release mode
-
-Enable full diagnostics in release for allocator analysis:
-
-```bash
-xmake f -c -m release --lunet_trace=n --lunet_verbose_trace=n --easy_memory_experimental=y --easy_memory_arena_mb=128 -y
-xmake build
-```
+Release builds should keep EasyMem stripped by default.
 
 ### Arena sizing
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -71,12 +71,6 @@ option("easy_memory")
     set_description("Enable EasyMem allocator backend (optional add-in)")
 option_end()
 
-option("easy_memory_experimental")
-    set_default(false)
-    set_showmenu(true)
-    set_description("EXPERIMENTAL: Enable EasyMem in release builds with full diagnostics")
-option_end()
-
 option("easy_memory_arena_mb")
     set_default("128")
     set_showmenu(true)
@@ -108,7 +102,6 @@ package_end()
 
 local function lunet_easy_memory_enabled()
     return has_config("easy_memory")
-        or has_config("easy_memory_experimental")
         or has_config("lunet_trace")
         or has_config("asan")
 end
@@ -116,7 +109,6 @@ end
 local function lunet_easy_memory_diagnostics_enabled()
     return has_config("lunet_trace")
         or has_config("asan")
-        or has_config("easy_memory_experimental")
 end
 
 local function lunet_easy_memory_arena_bytes()
@@ -736,18 +728,6 @@ task("build-debug")
     }
     on_run(function ()
         os.exec("xmake f -c -m debug --lunet_trace=y --lunet_verbose_trace=n -y")
-        os.exec("xmake build")
-    end)
-task_end()
-
-task("build-easy-memory-experimental")
-    set_menu {
-        usage = "xmake build-easy-memory-experimental",
-        description = "Configure and build EasyMem experimental release profile"
-    }
-    on_run(function ()
-        local arena_mb = os.getenv("EASY_MEMORY_ARENA_MB") or "128"
-        os.exec("xmake f -c -m release --lunet_trace=n --lunet_verbose_trace=n --easy_memory_experimental=y --easy_memory_arena_mb=" .. arena_mb .. " -y")
         os.exec("xmake build")
     end)
 task_end()


### PR DESCRIPTION
Remove EasyMem release build flags and documentation to ensure it is stripped from release builds by default.

EasyMem is intended for development and diagnostic purposes, not for optimized release builds, as discussed in issue #15. This PR removes all mechanisms and documentation that previously allowed or described enabling EasyMem in release configurations.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-cde533d3-39a4-4b8b-a159-d068b4b1d885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cde533d3-39a4-4b8b-a159-d068b4b1d885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

