### PR TITLE
feat(ext): add GraphLite ISO GQL graph database module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -452,6 +452,64 @@ jobs:
           exit $LASTEXITCODE
         }
 
+  graphlite:
+    name: graphlite (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
+
+    - name: Install xmake
+      uses: xmake-io/github-action-setup-xmake@v1
+      with:
+        xmake-version: latest
+
+    - name: Install Dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y pkg-config libuv1-dev luajit libluajit-5.1-dev
+
+    - name: Install Dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew install pkg-config libuv luajit
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: '1.87.0'
+
+    - name: Cache Cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          .tmp/graphlite-vendor/GraphLite/target
+        key: ${{ runner.os }}-cargo-graphlite-${{ hashFiles('xmake.lua') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-graphlite-
+
+    - name: Configure
+      run: xmake f -m release -y
+
+    - name: Build core
+      run: xmake build
+
+    - name: Build graphlite extension (clone + Rust FFI + C shim)
+      run: xmake build-graphlite
+
+    - name: Run graphlite smoke test
+      run: xmake graphlite-smoke
+
   publish-release:
     name: Publish release
     if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.ref, 'v'))

--- a/README-CN.md
+++ b/README-CN.md
@@ -23,6 +23,8 @@ Lunet 采用**模块化设计**。只构建你需要的：
   - `lunet.ngx_shared` - 受 nginx 启发的共享字典，通过 Rust FFI 实现（`xmake build-ngx-shared`）
 - **JSON**（可选 Rust 扩展，Linux/macOS）：
   - `lunet.jsonic` - dkjson 风格的编解码；解码通过 Rust FFI 封装 [jsonic](https://github.com/g1mv/jsonic)（`xmake build-jsonic`）
+- **图数据库**（可选 Rust 扩展，从源码构建，Linux/macOS）：
+  - `lunet.graphlite` - 基于 [GraphLite](https://github.com/GraphLite-AI/GraphLite) Rust FFI 的 ISO GQL 图数据库（`xmake build-graphlite`）
 
 只构建一个数据库驱动，而不是全部。没有未使用的依赖。不需要为从未使用的库打安全补丁。
 
@@ -252,6 +254,44 @@ json.encode({ a = 1 }, { indent = true, keyorder = { "a" } })
 将 jsonic 演示作为 Maelstrom(Jepsen)节点运行 —— Docker arm64、无卷挂载、
 仅回环 —— 通过 `make -C ext/jsonic/maelstrom test` 执行。
 
+### 图数据库（`lunet.graphlite`）— Linux / macOS
+
+基于 [GraphLite](https://github.com/GraphLite-AI/GraphLite) 的 ISO GQL
+(Graph Query Language) 图数据库，GraphLite 是一个用 Rust 编写的可嵌入图数据库。
+与 `ngx_shared`/`jsonic` 不同（它们的 Rust 源码在仓库内），GraphLite 没有官方
+平台包，因此其 `graphlite-ffi` crate 是从固定的上游 commit 按需由 xmake 克隆
+构建的。`lunet-graphlite` C 模块（`ext/graphlite/`）在运行时通过
+`dlopen`/`LoadLibrary` 动态加载生成的库，并像 SQLite3 驱动一样将调用分派到
+libuv 工作线程，具有相同的协程 yield/resume 语义。
+
+**构建**（需要 Rust 1.87+ / 2024 edition，通过 `rustup` 自动获取）：
+```bash
+xmake build-graphlite   # 克隆固定 commit 的 GraphLite、构建 Rust FFI cdylib、
+                         # 编译 lunet-graphlite C 桩代码
+```
+
+**使用示例**：
+```lua
+local gl = require("lunet.graphlite")
+
+local conn, err = gl.open({ path = "/tmp/mydb" })
+local session, err = gl.create_session(conn, "admin")
+
+gl.query(conn, session, "CREATE SCHEMA IF NOT EXISTS /example")
+gl.query(conn, session, "SESSION SET SCHEMA /example")
+gl.query(conn, session, "CREATE GRAPH IF NOT EXISTS social")
+gl.query(conn, session, "SESSION SET GRAPH social")
+
+gl.query(conn, session, "INSERT (:Person {name: 'Alice', age: 30})")
+local result, err = gl.query(conn, session, "MATCH (p:Person) RETURN p.name, p.age")
+
+gl.close_session(conn, session)
+gl.close(conn)
+```
+
+完整流程（模式/图 DDL、插入、模式匹配、过滤、聚合）见
+[`examples/10_graphlite_gql.lua`](examples/10_graphlite_gql.lua)。
+
 ## 安全性：零开销追踪
 
 使用 `xmake build-debug` 构建可启用协程引用追踪和栈完整性检查。运行时会在检测到泄漏或栈污染时触发断言并崩溃。
@@ -273,6 +313,8 @@ xmake 是标准构建系统。没有 Makefile。所有任务定义在 `xmake.lua
 | `xmake ngx-shared-smoke` | 构建 ngx_shared 并运行冒烟测试 |
 | `xmake build-jsonic` | 构建 jsonic Rust 扩展 |
 | `xmake jsonic-smoke` | 构建 jsonic 并运行冒烟测试 |
+| `xmake build-graphlite` | 构建 GraphLite Rust 扩展（克隆 + cargo build + C 桩代码） |
+| `xmake graphlite-smoke` | 构建 GraphLite 扩展并运行示例冒烟测试 |
 | `xmake stress` | 带追踪的并发压力测试 |
 | `xmake ci` | 本地 CI 一致性检查（lint + 构建 + 示例 + sqlite3 冒烟） |
 | `xmake preflight-easy-memory` | EasyMem + ASan 预检门控 |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Lunet is **modular by design**. You build only what you need:
   - `lunet.ngx_shared` - nginx-inspired shared dict via Rust FFI (`xmake build-ngx-shared`)
 - **JSON** (optional Rust extension, Linux/macOS):
   - `lunet.jsonic` - dkjson-style encode/decode; decode via Rust FFI wrapping [jsonic](https://github.com/g1mv/jsonic) (`xmake build-jsonic`)
+- **Graph database** (optional Rust extension, vendored from source, Linux/macOS):
+  - `lunet.graphlite` - ISO GQL graph database via [GraphLite](https://github.com/GraphLite-AI/GraphLite) Rust FFI (`xmake build-graphlite`)
 
 Build one database driver, not all three. No unused dependencies. No security patches for libraries you never use.
 
@@ -100,6 +102,7 @@ LUNET_BIN=$(find build -path '*/release/lunet-run' -type f 2>/dev/null | head -1
 | 05 | [`examples/05_db_postgres.lua`](examples/05_db_postgres.lua) | Postgres CRUD + prepared statements (`$1`) | `xmake build lunet-postgres` + Postgres server | `"$LUNET_BIN" examples/05_db_postgres.lua` |
 | 08 | [`examples/08_ngx_shared.lua`](examples/08_ngx_shared.lua) | nginx-style shared dictionary via Rust FFI | `xmake build-ngx-shared` | `"$LUNET_BIN" examples/08_ngx_shared.lua` |
 | 09 | [`examples/09_jsonic_demo.lua`](examples/09_jsonic_demo.lua) | dkjson-style JSON encode/decode via Rust FFI | `xmake build-jsonic` | `"$LUNET_BIN" examples/09_jsonic_demo.lua` |
+| 10 | [`examples/10_graphlite_gql.lua`](examples/10_graphlite_gql.lua) | ISO GQL graph database CRUD via Rust FFI | `xmake build-graphlite` | `"$LUNET_BIN" examples/10_graphlite_gql.lua` |
 
 See also [lunet-realworld-example-app](https://github.com/lua-lunet/lunet-realworld-example-app) for a complete RealWorld "Conduit" API implementation.
 
@@ -316,6 +319,47 @@ json.encode({ a = 1 }, { indent = true, keyorder = { "a" } })
 runs the jsonic demo as a Maelstrom (Jepsen) node — Docker on arm64, no
 volume mounts, loopback-only — via `make -C ext/jsonic/maelstrom test`.
 
+### Graph database (`lunet.graphlite`) — Linux / macOS
+
+An ISO GQL (Graph Query Language) graph database powered by
+[GraphLite](https://github.com/GraphLite-AI/GraphLite), an embeddable graph
+database written in Rust. Unlike `ngx_shared`/`jsonic`, whose Rust source
+lives in-repo, GraphLite has no official platform packages, so its
+`graphlite-ffi` crate is built from a pinned upstream commit that xmake
+clones on demand. The `lunet-graphlite` C module (`ext/graphlite/`)
+dynamically loads the resulting library via `dlopen`/`LoadLibrary` at
+runtime, dispatching to libuv worker threads with the same coroutine
+yield/resume semantics as the SQLite3 driver.
+
+**Build** (requires Rust 1.87+ / 2024 edition, fetched automatically via `rustup`):
+```bash
+xmake build-graphlite   # clones GraphLite at a pinned commit, builds the
+                         # Rust FFI cdylib, compiles the lunet-graphlite C shim
+```
+
+**Usage**:
+```lua
+local gl = require("lunet.graphlite")
+
+local conn, err = gl.open({ path = "/tmp/mydb" })
+local session, err = gl.create_session(conn, "admin")
+
+gl.query(conn, session, "CREATE SCHEMA IF NOT EXISTS /example")
+gl.query(conn, session, "SESSION SET SCHEMA /example")
+gl.query(conn, session, "CREATE GRAPH IF NOT EXISTS social")
+gl.query(conn, session, "SESSION SET GRAPH social")
+
+gl.query(conn, session, "INSERT (:Person {name: 'Alice', age: 30})")
+local result, err = gl.query(conn, session, "MATCH (p:Person) RETURN p.name, p.age")
+
+gl.close_session(conn, session)
+gl.close(conn)
+```
+
+See [`examples/10_graphlite_gql.lua`](examples/10_graphlite_gql.lua) for a
+full walkthrough (schema/graph DDL, inserts, pattern matching, filtering,
+aggregation).
+
 ## Safety: Zero-Cost Tracing
 
 Build with `xmake build-debug` to enable coroutine reference tracking and stack integrity checks. The runtime will assert and crash on leaks or stack pollution.
@@ -464,6 +508,8 @@ xmake is the canonical build system. There is no Makefile. All tasks are defined
 | `xmake ngx-shared-smoke` | Build ngx_shared then run its smoke test |
 | `xmake build-jsonic` | Build the jsonic Rust extension |
 | `xmake jsonic-smoke` | Build jsonic then run its smoke test |
+| `xmake build-graphlite` | Build the GraphLite Rust extension (clone + cargo build + C shim) |
+| `xmake graphlite-smoke` | Build the GraphLite extension then run its example smoke test |
 | `xmake stress` | Concurrent load test with tracing |
 | `xmake ci` | Local CI parity (lint + build + examples + sqlite3 smoke) |
 | `xmake preflight-easy-memory` | EasyMem + ASan preflight gate |

--- a/examples/10_graphlite_gql.lua
+++ b/examples/10_graphlite_gql.lua
@@ -1,0 +1,190 @@
+--[[
+GraphLite GQL (Graph Query Language) Demo for lunet
+
+This example mirrors the Python SDK basic_usage.py from GraphLite-AI/GraphLite.
+It demonstrates the core features of the GraphLite graph database via the
+lunet.graphlite coroutine-safe module:
+
+  - Opening a database (via dynamically loaded Rust FFI library)
+  - Creating sessions
+  - Executing ISO GQL queries (DDL, DML, DQL)
+  - Pattern matching with MATCH clauses
+  - Filtering with WHERE
+  - Aggregation and ordering
+
+GraphLite is an embeddable graph database written in Rust that implements
+the ISO GQL (Graph Query Language) standard.
+
+Prerequisites — building the GraphLite FFI library and lunet module:
+
+  Step 1: Build core lunet (if not already built)
+    xmake f -m release -y
+    xmake build
+
+  Step 2: Build the GraphLite extension (fetches, builds Rust FFI lib, compiles C shim)
+    xmake build-graphlite
+
+  Step 3: Run this example
+    xmake graphlite-smoke
+
+  Or manually:
+    LUNET_BIN=$(find build -path '*/release/lunet-run' -type f 2>/dev/null | head -1)
+    LIB_DIR=$(find build -path '*/release/lunet' -type d 2>/dev/null | head -1)
+    LD_LIBRARY_PATH="$LIB_DIR:$LD_LIBRARY_PATH" "$LUNET_BIN" examples/10_graphlite_gql.lua
+
+What happens under the hood:
+  1. xmake build-graphlite clones GraphLite-AI/GraphLite at a pinned commit
+  2. Builds the `graphlite-ffi` Rust crate with `cargo build --release`
+  3. This produces libgraphlite_ffi.so / .dylib / .dll (C FFI shared library)
+  4. The lunet-graphlite C module (ext/graphlite/graphlite.c) uses dlopen()
+     to load the Rust library at runtime
+  5. All database operations are dispatched to libuv worker threads, yielding
+     the calling coroutine exactly like the SQLite3 driver does
+
+The GraphLite FFI API (from graphlite-ffi/graphlite.h):
+  graphlite_open(path, &error)        -> GraphLiteDB*
+  graphlite_create_session(db, user)  -> session_id string
+  graphlite_query(db, session, gql)   -> JSON string with results
+  graphlite_close_session(db, sid)    -> error code
+  graphlite_close(db)                 -> void
+  graphlite_version()                 -> version string
+]]
+
+local lunet = require("lunet")
+local gl = require("lunet.graphlite")
+
+lunet.spawn(function()
+    print("=== GraphLite GQL Database Demo ===")
+    print()
+
+    -- 1. Open a database (uses a temporary directory)
+    --    The `lib` field is optional — if omitted, it looks for the FFI lib
+    --    in the default system library search path.
+    print("1. Opening database...")
+    local db_path = "/tmp/lunet_graphlite_demo_" .. os.time()
+    local conn, err = gl.open({ path = db_path })
+    if not conn then
+        print("Failed to open database:", err)
+        return
+    end
+    print("   Database opened at " .. db_path)
+    print()
+
+    -- 2. Create a session
+    print("2. Creating session...")
+    local session, err = gl.create_session(conn, "admin")
+    if not session then
+        print("Failed to create session:", err)
+        gl.close(conn)
+        return
+    end
+    print("   Session created for user 'admin'")
+    print()
+
+    -- 3. Create schema and graph (DDL)
+    --    GraphLite uses ISO GQL syntax for schema and graph management
+    print("3. Creating schema and graph...")
+    local result, err = gl.query(conn, session, "CREATE SCHEMA IF NOT EXISTS /example")
+    if err then
+        print("   Schema creation warning:", err)
+    end
+
+    result, err = gl.query(conn, session, "SESSION SET SCHEMA /example")
+    if err then
+        print("   Set schema error:", err)
+        gl.close(conn)
+        return
+    end
+
+    result, err = gl.query(conn, session, "CREATE GRAPH IF NOT EXISTS social")
+    if err then
+        print("   Graph creation warning:", err)
+    end
+
+    result, err = gl.query(conn, session, "SESSION SET GRAPH social")
+    if err then
+        print("   Set graph error:", err)
+        gl.close(conn)
+        return
+    end
+    print("   Schema '/example' and graph 'social' created")
+    print()
+
+    -- 4. Insert data (DML)
+    --    Insert Person nodes with name and age properties
+    print("4. Inserting data...")
+    local people = {
+        {name = "Alice",   age = 30},
+        {name = "Bob",     age = 25},
+        {name = "Charlie", age = 35},
+        {name = "David",   age = 28},
+        {name = "Eve",     age = 23},
+        {name = "Frank",   age = 40},
+    }
+
+    for _, p in ipairs(people) do
+        local gql = string.format(
+            "INSERT (p:Person {name: '%s', age: %d})", p.name, p.age)
+        local result, err = gl.query(conn, session, gql)
+        if err then
+            print("   Insert failed for " .. p.name .. ":", err)
+        end
+    end
+    print("   Inserted " .. #people .. " persons")
+    print()
+
+    -- 5. Query all persons (DQL with MATCH)
+    --    ISO GQL uses MATCH for pattern matching in the graph
+    print("5. Querying all persons...")
+    local json, err = gl.query(conn, session,
+        "MATCH (p:Person) RETURN p.name as name, p.age as age")
+    if err then
+        print("   Query failed:", err)
+    else
+        print("   Result (JSON): " .. json)
+    end
+    print()
+
+    -- 6. Filter with WHERE clause
+    --    Find persons over age 25, ordered by age descending
+    print("6. Querying persons over 25...")
+    json, err = gl.query(conn, session,
+        "MATCH (p:Person) WHERE p.age > 25 RETURN p.name as name, p.age as age")
+    if err then
+        print("   Query failed:", err)
+    else
+        print("   Result (JSON): " .. json)
+    end
+    print()
+
+    -- 7. Aggregation
+    --    Count all persons in the graph
+    print("7. Counting all persons...")
+    json, err = gl.query(conn, session,
+        "MATCH (p:Person) RETURN count(p) as count")
+    if err then
+        print("   Count query failed:", err)
+    else
+        print("   Result (JSON): " .. json)
+    end
+    print()
+
+    -- 8. Get GraphLite version
+    print("8. GraphLite version: " .. gl.version())
+    print()
+
+    -- 9. Clean up
+    print("9. Cleaning up...")
+    local ok, err = gl.close_session(conn, session)
+    if err then
+        print("   Close session warning:", err)
+    end
+
+    gl.close(conn)
+    print("   Database closed.")
+    print()
+    print("=== Demo complete! ===")
+
+    -- Clean up temporary database directory
+    os.execute("rm -rf " .. db_path)
+end)

--- a/ext/graphlite/graphlite.c
+++ b/ext/graphlite/graphlite.c
@@ -1,0 +1,700 @@
+#include "lunet_graphlite.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "co.h"
+#include "trace.h"
+#include "lunet_mem.h"
+#include "uv.h"
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#include <windows.h>
+typedef HMODULE gl_lib_t;
+#define GL_DLOPEN(p) LoadLibraryA(p)
+#define GL_DLSYM(h, s) ((void*)GetProcAddress((h), (s)))
+#define GL_DLCLOSE(h) FreeLibrary(h)
+static const char* gl_dlerror(void) {
+  static char buf[256];
+  FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, GetLastError(),
+                 0, buf, sizeof(buf), NULL);
+  return buf;
+}
+#else
+#include <dlfcn.h>
+typedef void* gl_lib_t;
+#define GL_DLOPEN(p) dlopen((p), RTLD_NOW | RTLD_LOCAL)
+#define GL_DLSYM(h, s) dlsym((h), (s))
+#define GL_DLCLOSE(h) dlclose(h)
+static const char* gl_dlerror(void) { return dlerror(); }
+#endif
+
+typedef enum {
+  GL_SUCCESS = 0,
+  GL_NULL_POINTER = 1,
+  GL_INVALID_UTF8 = 2,
+  GL_DB_OPEN_ERROR = 3,
+  GL_SESSION_ERROR = 4,
+  GL_QUERY_ERROR = 5,
+  GL_PANIC_ERROR = 6,
+  GL_JSON_ERROR = 7
+} gl_error_code_t;
+
+typedef struct gl_db gl_db_t;
+
+typedef gl_db_t* (*fn_graphlite_open)(const char* path, gl_error_code_t* err);
+typedef char* (*fn_graphlite_create_session)(gl_db_t* db, const char* user,
+                                             gl_error_code_t* err);
+typedef char* (*fn_graphlite_query)(gl_db_t* db, const char* session,
+                                    const char* query, gl_error_code_t* err);
+typedef gl_error_code_t (*fn_graphlite_close_session)(gl_db_t* db,
+                                                       const char* session,
+                                                       gl_error_code_t* err);
+typedef void (*fn_graphlite_free_string)(char* s);
+typedef void (*fn_graphlite_close)(gl_db_t* db);
+typedef const char* (*fn_graphlite_version)(void);
+
+typedef struct {
+  gl_lib_t handle;
+  fn_graphlite_open open;
+  fn_graphlite_create_session create_session;
+  fn_graphlite_query query;
+  fn_graphlite_close_session close_session;
+  fn_graphlite_free_string free_string;
+  fn_graphlite_close close;
+  fn_graphlite_version version;
+} gl_vtable_t;
+
+static gl_vtable_t g_gl = {0};
+
+static const char* gl_error_string(gl_error_code_t code) {
+  switch (code) {
+    case GL_SUCCESS:        return "success";
+    case GL_NULL_POINTER:   return "null pointer";
+    case GL_INVALID_UTF8:   return "invalid UTF-8";
+    case GL_DB_OPEN_ERROR:  return "database open failed";
+    case GL_SESSION_ERROR:  return "session error";
+    case GL_QUERY_ERROR:    return "query error";
+    case GL_PANIC_ERROR:    return "internal panic";
+    case GL_JSON_ERROR:     return "JSON serialization error";
+  }
+  return "unknown error";
+}
+
+static int gl_load_library(const char* lib_path, char* err, size_t errsize) {
+  if (g_gl.handle) return 0;
+
+  g_gl.handle = GL_DLOPEN(lib_path);
+  if (!g_gl.handle) {
+    const char* dle = gl_dlerror();
+    snprintf(err, errsize, "dlopen: %.200s", dle ? dle : "unknown error");
+    return -1;
+  }
+
+#define GL_RESOLVE(name)                                                    \
+  g_gl.name = (fn_graphlite_##name)GL_DLSYM(g_gl.handle,                   \
+                                              "graphlite_" #name);          \
+  if (!g_gl.name) {                                                         \
+    snprintf(err, errsize, "missing symbol: graphlite_" #name);             \
+    GL_DLCLOSE(g_gl.handle);                                                \
+    memset(&g_gl, 0, sizeof(g_gl));                                         \
+    return -1;                                                              \
+  }
+
+  GL_RESOLVE(open)
+  GL_RESOLVE(create_session)
+  GL_RESOLVE(query)
+  GL_RESOLVE(close_session)
+  GL_RESOLVE(free_string)
+  GL_RESOLVE(close)
+  GL_RESOLVE(version)
+
+#undef GL_RESOLVE
+  return 0;
+}
+
+#define LUNET_GRAPHLITE_CONN_MT "lunet.graphlite.conn"
+
+static char* lunet_strdup_local(const char* s) {
+  if (!s) return NULL;
+  size_t len = strlen(s);
+  char* out = lunet_alloc(len + 1);
+  if (!out) return NULL;
+  memcpy(out, s, len + 1);
+  return out;
+}
+
+typedef struct {
+  gl_db_t* db;
+  uv_mutex_t mutex;
+  int closed;
+} lunet_gl_conn_t;
+
+static void lunet_gl_conn_close(lunet_gl_conn_t* w) {
+  if (!w || w->closed) return;
+  w->closed = 1;
+  if (w->db && g_gl.close) {
+    g_gl.close(w->db);
+    w->db = NULL;
+  }
+}
+
+static void lunet_gl_conn_destroy(lunet_gl_conn_t* w) {
+  lunet_gl_conn_close(w);
+  if (w) {
+    uv_mutex_destroy(&w->mutex);
+  }
+}
+
+static int conn_gc(lua_State* L) {
+  lunet_gl_conn_t* w =
+      (lunet_gl_conn_t*)luaL_checkudata(L, 1, LUNET_GRAPHLITE_CONN_MT);
+  lunet_gl_conn_destroy(w);
+  return 0;
+}
+
+static void register_conn_metatable(lua_State* L) {
+  if (luaL_newmetatable(L, LUNET_GRAPHLITE_CONN_MT)) {
+    lua_pushcfunction(L, conn_gc);
+    lua_setfield(L, -2, "__gc");
+  }
+  lua_pop(L, 1);
+}
+
+typedef struct {
+  uv_work_t req;
+  lua_State* L;
+  int co_ref;
+  gl_db_t* db;
+  char err[256];
+  char path[1024];
+  char lib_path[1024];
+} gl_open_ctx_t;
+
+static void gl_open_work_cb(uv_work_t* req) {
+  gl_open_ctx_t* ctx = (gl_open_ctx_t*)req->data;
+
+  if (!g_gl.handle) {
+    if (gl_load_library(ctx->lib_path, ctx->err, sizeof(ctx->err)) != 0) {
+      return;
+    }
+  }
+
+  gl_error_code_t ec = GL_SUCCESS;
+  ctx->db = g_gl.open(ctx->path, &ec);
+  if (!ctx->db) {
+    snprintf(ctx->err, sizeof(ctx->err), "graphlite_open: %s",
+             gl_error_string(ec));
+  }
+}
+
+static void gl_open_after_cb(uv_work_t* req, int status) {
+  gl_open_ctx_t* ctx = (gl_open_ctx_t*)req->data;
+  lua_State* L = ctx->L;
+
+  lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->co_ref);
+  lunet_coref_release(L, ctx->co_ref);
+  if (!lua_isthread(L, -1)) {
+    lua_pop(L, 1);
+    fprintf(stderr, "invalid coroutine in graphlite.open\n");
+    if (ctx->db && g_gl.close) g_gl.close(ctx->db);
+    lunet_free_nonnull(ctx);
+    return;
+  }
+  lua_State* co = lua_tothread(L, -1);
+  lua_pop(L, 1);
+
+  if (ctx->db) {
+    lunet_gl_conn_t* w =
+        (lunet_gl_conn_t*)lua_newuserdata(co, sizeof(lunet_gl_conn_t));
+    w->db = ctx->db;
+    w->closed = 0;
+    uv_mutex_init(&w->mutex);
+    luaL_getmetatable(co, LUNET_GRAPHLITE_CONN_MT);
+    lua_setmetatable(co, -2);
+    lua_pushnil(co);
+  } else {
+    lua_pushnil(co);
+    lua_pushstring(co, ctx->err);
+  }
+  int rc = lunet_co_resume(co, 2);
+  if (rc != 0 && rc != LUA_YIELD) {
+    const char* e = lua_tostring(co, -1);
+    if (e) fprintf(stderr, "lua_resume error in graphlite.open: %s\n", e);
+    lua_pop(co, 1);
+  }
+  lunet_free_nonnull(ctx);
+}
+
+int lunet_graphlite_open(lua_State* L) {
+  if (lunet_ensure_coroutine(L, "graphlite.open")) {
+    return lua_error(L);
+  }
+  if (lua_gettop(L) < 1 || !lua_istable(L, 1)) {
+    lua_pushstring(L, "graphlite.open requires params table");
+    return lua_error(L);
+  }
+
+  register_conn_metatable(L);
+
+  gl_open_ctx_t* ctx = lunet_alloc(sizeof(gl_open_ctx_t));
+  if (!ctx) {
+    lua_pushnil(L);
+    lua_pushstring(L, "graphlite.open: out of memory");
+    return lua_error(L);
+  }
+  memset(ctx, 0, sizeof(*ctx));
+  ctx->L = L;
+  ctx->req.data = ctx;
+
+  lua_getfield(L, 1, "path");
+  const char* dbpath = luaL_checkstring(L, -1);
+  snprintf(ctx->path, sizeof(ctx->path), "%s", dbpath);
+  lua_pop(L, 1);
+
+  lua_getfield(L, 1, "lib");
+  const char* libpath = luaL_optstring(L, -1, NULL);
+  if (libpath) {
+    snprintf(ctx->lib_path, sizeof(ctx->lib_path), "%s", libpath);
+  } else {
+#if defined(_WIN32)
+    snprintf(ctx->lib_path, sizeof(ctx->lib_path), "graphlite_ffi.dll");
+#elif defined(__APPLE__)
+    snprintf(ctx->lib_path, sizeof(ctx->lib_path), "libgraphlite_ffi.dylib");
+#else
+    snprintf(ctx->lib_path, sizeof(ctx->lib_path), "libgraphlite_ffi.so");
+#endif
+  }
+  lua_pop(L, 1);
+
+  lunet_coref_create(L, ctx->co_ref);
+
+  int ret = uv_queue_work(uv_default_loop(), &ctx->req, gl_open_work_cb,
+                           gl_open_after_cb);
+  if (ret < 0) {
+    lunet_coref_release(L, ctx->co_ref);
+    lunet_free_nonnull(ctx);
+    lua_pushnil(L);
+    lua_pushfstring(L, "graphlite.open: uv_queue_work failed: %s",
+                    uv_strerror(ret));
+    return lua_error(L);
+  }
+
+  return lua_yield(L, 0);
+}
+
+int lunet_graphlite_close(lua_State* L) {
+  if (lunet_ensure_coroutine(L, "graphlite.close")) {
+    return lua_error(L);
+  }
+  if (lua_gettop(L) < 1) {
+    lua_pushstring(L, "graphlite.close requires a connection");
+    return 1;
+  }
+  lunet_gl_conn_t* w =
+      (lunet_gl_conn_t*)luaL_testudata(L, 1, LUNET_GRAPHLITE_CONN_MT);
+  if (!w) {
+    lua_pushstring(L, "graphlite.close requires a valid connection");
+    return 1;
+  }
+
+  uv_mutex_lock(&w->mutex);
+  lunet_gl_conn_close(w);
+  uv_mutex_unlock(&w->mutex);
+
+  lua_pushnil(L);
+  return 1;
+}
+
+typedef struct {
+  uv_work_t req;
+  lua_State* L;
+  int co_ref;
+  lunet_gl_conn_t* wrapper;
+  char* username;
+  char* session_id;
+  char err[256];
+} gl_session_ctx_t;
+
+static void gl_create_session_work_cb(uv_work_t* req) {
+  gl_session_ctx_t* ctx = (gl_session_ctx_t*)req->data;
+
+  uv_mutex_lock(&ctx->wrapper->mutex);
+  if (ctx->wrapper->closed || !ctx->wrapper->db) {
+    snprintf(ctx->err, sizeof(ctx->err), "connection is closed");
+    uv_mutex_unlock(&ctx->wrapper->mutex);
+    return;
+  }
+
+  gl_error_code_t ec = GL_SUCCESS;
+  char* sid = g_gl.create_session(ctx->wrapper->db, ctx->username, &ec);
+  if (!sid) {
+    snprintf(ctx->err, sizeof(ctx->err), "graphlite_create_session: %s",
+             gl_error_string(ec));
+    uv_mutex_unlock(&ctx->wrapper->mutex);
+    return;
+  }
+  ctx->session_id = lunet_strdup_local(sid);
+  g_gl.free_string(sid);
+  uv_mutex_unlock(&ctx->wrapper->mutex);
+}
+
+static void gl_create_session_after_cb(uv_work_t* req, int status) {
+  gl_session_ctx_t* ctx = (gl_session_ctx_t*)req->data;
+  lua_State* L = ctx->L;
+
+  lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->co_ref);
+  lunet_coref_release(L, ctx->co_ref);
+  if (!lua_isthread(L, -1)) {
+    lua_pop(L, 1);
+    fprintf(stderr, "invalid coroutine in graphlite.create_session\n");
+    goto cleanup;
+  }
+  lua_State* co = lua_tothread(L, -1);
+  lua_pop(L, 1);
+
+  if (ctx->err[0] != '\0') {
+    lua_pushnil(co);
+    lua_pushstring(co, ctx->err);
+  } else {
+    lua_pushstring(co, ctx->session_id);
+    lua_pushnil(co);
+  }
+  {
+    int rc = lunet_co_resume(co, 2);
+    if (rc != 0 && rc != LUA_YIELD) {
+      const char* e = lua_tostring(co, -1);
+      if (e) fprintf(stderr, "lua_resume error in graphlite.create_session: %s\n", e);
+      lua_pop(co, 1);
+    }
+  }
+
+cleanup:
+  lunet_free_nonnull(ctx->username);
+  lunet_free_nonnull(ctx->session_id);
+  lunet_free_nonnull(ctx);
+}
+
+int lunet_graphlite_create_session(lua_State* L) {
+  if (lunet_ensure_coroutine(L, "graphlite.create_session")) {
+    return lua_error(L);
+  }
+  if (lua_gettop(L) < 2) {
+    lua_pushnil(L);
+    lua_pushstring(L, "graphlite.create_session requires connection and username");
+    return 2;
+  }
+
+  lunet_gl_conn_t* w =
+      (lunet_gl_conn_t*)luaL_testudata(L, 1, LUNET_GRAPHLITE_CONN_MT);
+  if (!w) {
+    lua_pushnil(L);
+    lua_pushstring(L, "graphlite.create_session requires a valid connection");
+    return 2;
+  }
+  if (w->closed || !w->db) {
+    lua_pushnil(L);
+    lua_pushstring(L, "connection is closed");
+    return 2;
+  }
+
+  const char* username = luaL_checkstring(L, 2);
+
+  gl_session_ctx_t* ctx = lunet_alloc(sizeof(gl_session_ctx_t));
+  if (!ctx) {
+    lua_pushnil(L);
+    lua_pushstring(L, "out of memory");
+    return 2;
+  }
+  memset(ctx, 0, sizeof(*ctx));
+  ctx->L = L;
+  ctx->req.data = ctx;
+  ctx->wrapper = w;
+  ctx->username = lunet_strdup_local(username);
+  if (!ctx->username) {
+    lunet_free_nonnull(ctx);
+    lua_pushnil(L);
+    lua_pushstring(L, "out of memory");
+    return 2;
+  }
+
+  lunet_coref_create(L, ctx->co_ref);
+
+  int ret = uv_queue_work(uv_default_loop(), &ctx->req,
+                           gl_create_session_work_cb,
+                           gl_create_session_after_cb);
+  if (ret < 0) {
+    lunet_coref_release(L, ctx->co_ref);
+    lunet_free_nonnull(ctx->username);
+    lunet_free_nonnull(ctx);
+    lua_pushnil(L);
+    lua_pushstring(L, uv_strerror(ret));
+    return 2;
+  }
+
+  return lua_yield(L, 0);
+}
+
+typedef struct {
+  uv_work_t req;
+  lua_State* L;
+  int co_ref;
+  lunet_gl_conn_t* wrapper;
+  char* session_id;
+  char err[256];
+} gl_close_session_ctx_t;
+
+static void gl_close_session_work_cb(uv_work_t* req) {
+  gl_close_session_ctx_t* ctx = (gl_close_session_ctx_t*)req->data;
+
+  uv_mutex_lock(&ctx->wrapper->mutex);
+  if (ctx->wrapper->closed || !ctx->wrapper->db) {
+    snprintf(ctx->err, sizeof(ctx->err), "connection is closed");
+    uv_mutex_unlock(&ctx->wrapper->mutex);
+    return;
+  }
+
+  gl_error_code_t ec = GL_SUCCESS;
+  g_gl.close_session(ctx->wrapper->db, ctx->session_id, &ec);
+  if (ec != GL_SUCCESS) {
+    snprintf(ctx->err, sizeof(ctx->err), "graphlite_close_session: %s",
+             gl_error_string(ec));
+  }
+  uv_mutex_unlock(&ctx->wrapper->mutex);
+}
+
+static void gl_close_session_after_cb(uv_work_t* req, int status) {
+  gl_close_session_ctx_t* ctx = (gl_close_session_ctx_t*)req->data;
+  lua_State* L = ctx->L;
+
+  lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->co_ref);
+  lunet_coref_release(L, ctx->co_ref);
+  if (!lua_isthread(L, -1)) {
+    lua_pop(L, 1);
+    fprintf(stderr, "invalid coroutine in graphlite.close_session\n");
+    goto cleanup;
+  }
+  lua_State* co = lua_tothread(L, -1);
+  lua_pop(L, 1);
+
+  if (ctx->err[0] != '\0') {
+    lua_pushnil(co);
+    lua_pushstring(co, ctx->err);
+  } else {
+    lua_pushboolean(co, 1);
+    lua_pushnil(co);
+  }
+  {
+    int rc = lunet_co_resume(co, 2);
+    if (rc != 0 && rc != LUA_YIELD) {
+      const char* e = lua_tostring(co, -1);
+      if (e) fprintf(stderr, "lua_resume error in graphlite.close_session: %s\n", e);
+      lua_pop(co, 1);
+    }
+  }
+
+cleanup:
+  lunet_free_nonnull(ctx->session_id);
+  lunet_free_nonnull(ctx);
+}
+
+int lunet_graphlite_close_session(lua_State* L) {
+  if (lunet_ensure_coroutine(L, "graphlite.close_session")) {
+    return lua_error(L);
+  }
+  if (lua_gettop(L) < 2) {
+    lua_pushnil(L);
+    lua_pushstring(L, "graphlite.close_session requires connection and session_id");
+    return 2;
+  }
+
+  lunet_gl_conn_t* w =
+      (lunet_gl_conn_t*)luaL_testudata(L, 1, LUNET_GRAPHLITE_CONN_MT);
+  if (!w) {
+    lua_pushnil(L);
+    lua_pushstring(L, "graphlite.close_session requires a valid connection");
+    return 2;
+  }
+
+  const char* session_id = luaL_checkstring(L, 2);
+
+  gl_close_session_ctx_t* ctx = lunet_alloc(sizeof(gl_close_session_ctx_t));
+  if (!ctx) {
+    lua_pushnil(L);
+    lua_pushstring(L, "out of memory");
+    return 2;
+  }
+  memset(ctx, 0, sizeof(*ctx));
+  ctx->L = L;
+  ctx->req.data = ctx;
+  ctx->wrapper = w;
+  ctx->session_id = lunet_strdup_local(session_id);
+  if (!ctx->session_id) {
+    lunet_free_nonnull(ctx);
+    lua_pushnil(L);
+    lua_pushstring(L, "out of memory");
+    return 2;
+  }
+
+  lunet_coref_create(L, ctx->co_ref);
+
+  int ret = uv_queue_work(uv_default_loop(), &ctx->req,
+                           gl_close_session_work_cb,
+                           gl_close_session_after_cb);
+  if (ret < 0) {
+    lunet_coref_release(L, ctx->co_ref);
+    lunet_free_nonnull(ctx->session_id);
+    lunet_free_nonnull(ctx);
+    lua_pushnil(L);
+    lua_pushstring(L, uv_strerror(ret));
+    return 2;
+  }
+
+  return lua_yield(L, 0);
+}
+
+typedef struct {
+  uv_work_t req;
+  lua_State* L;
+  int co_ref;
+  lunet_gl_conn_t* wrapper;
+  char* session_id;
+  char* gql;
+  char* result_json;
+  char err[256];
+} gl_query_ctx_t;
+
+static void gl_query_work_cb(uv_work_t* req) {
+  gl_query_ctx_t* ctx = (gl_query_ctx_t*)req->data;
+
+  uv_mutex_lock(&ctx->wrapper->mutex);
+  if (ctx->wrapper->closed || !ctx->wrapper->db) {
+    snprintf(ctx->err, sizeof(ctx->err), "connection is closed");
+    uv_mutex_unlock(&ctx->wrapper->mutex);
+    return;
+  }
+
+  gl_error_code_t ec = GL_SUCCESS;
+  char* json = g_gl.query(ctx->wrapper->db, ctx->session_id, ctx->gql, &ec);
+  if (!json) {
+    snprintf(ctx->err, sizeof(ctx->err), "graphlite_query: %s",
+             gl_error_string(ec));
+    uv_mutex_unlock(&ctx->wrapper->mutex);
+    return;
+  }
+  ctx->result_json = lunet_strdup_local(json);
+  g_gl.free_string(json);
+  uv_mutex_unlock(&ctx->wrapper->mutex);
+}
+
+static void gl_query_after_cb(uv_work_t* req, int status) {
+  gl_query_ctx_t* ctx = (gl_query_ctx_t*)req->data;
+  lua_State* L = ctx->L;
+
+  lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->co_ref);
+  lunet_coref_release(L, ctx->co_ref);
+  if (!lua_isthread(L, -1)) {
+    lua_pop(L, 1);
+    fprintf(stderr, "invalid coroutine in graphlite.query\n");
+    goto cleanup;
+  }
+  lua_State* co = lua_tothread(L, -1);
+  lua_pop(L, 1);
+
+  if (ctx->err[0] != '\0') {
+    lua_pushnil(co);
+    lua_pushstring(co, ctx->err);
+  } else {
+    lua_pushstring(co, ctx->result_json ? ctx->result_json : "{}");
+    lua_pushnil(co);
+  }
+  {
+    int rc = lunet_co_resume(co, 2);
+    if (rc != 0 && rc != LUA_YIELD) {
+      const char* e = lua_tostring(co, -1);
+      if (e) fprintf(stderr, "lua_resume error in graphlite.query: %s\n", e);
+      lua_pop(co, 1);
+    }
+  }
+
+cleanup:
+  lunet_free_nonnull(ctx->session_id);
+  lunet_free_nonnull(ctx->gql);
+  lunet_free_nonnull(ctx->result_json);
+  lunet_free_nonnull(ctx);
+}
+
+int lunet_graphlite_query(lua_State* L) {
+  if (lunet_ensure_coroutine(L, "graphlite.query")) {
+    return lua_error(L);
+  }
+  if (lua_gettop(L) < 3) {
+    lua_pushnil(L);
+    lua_pushstring(L,
+        "graphlite.query requires connection, session_id, and GQL string");
+    return 2;
+  }
+
+  lunet_gl_conn_t* w =
+      (lunet_gl_conn_t*)luaL_testudata(L, 1, LUNET_GRAPHLITE_CONN_MT);
+  if (!w) {
+    lua_pushnil(L);
+    lua_pushstring(L, "graphlite.query requires a valid connection");
+    return 2;
+  }
+  if (w->closed || !w->db) {
+    lua_pushnil(L);
+    lua_pushstring(L, "connection is closed");
+    return 2;
+  }
+
+  const char* session_id = luaL_checkstring(L, 2);
+  const char* gql = luaL_checkstring(L, 3);
+
+  gl_query_ctx_t* ctx = lunet_alloc(sizeof(gl_query_ctx_t));
+  if (!ctx) {
+    lua_pushnil(L);
+    lua_pushstring(L, "out of memory");
+    return 2;
+  }
+  memset(ctx, 0, sizeof(*ctx));
+  ctx->L = L;
+  ctx->req.data = ctx;
+  ctx->wrapper = w;
+  ctx->session_id = lunet_strdup_local(session_id);
+  ctx->gql = lunet_strdup_local(gql);
+  if (!ctx->session_id || !ctx->gql) {
+    lunet_free_nonnull(ctx->session_id);
+    lunet_free_nonnull(ctx->gql);
+    lunet_free_nonnull(ctx);
+    lua_pushnil(L);
+    lua_pushstring(L, "out of memory");
+    return 2;
+  }
+
+  lunet_coref_create(L, ctx->co_ref);
+
+  int ret = uv_queue_work(uv_default_loop(), &ctx->req, gl_query_work_cb,
+                           gl_query_after_cb);
+  if (ret < 0) {
+    lunet_coref_release(L, ctx->co_ref);
+    lunet_free_nonnull(ctx->session_id);
+    lunet_free_nonnull(ctx->gql);
+    lunet_free_nonnull(ctx);
+    lua_pushnil(L);
+    lua_pushstring(L, uv_strerror(ret));
+    return 2;
+  }
+
+  return lua_yield(L, 0);
+}
+
+int lunet_graphlite_version(lua_State* L) {
+  if (!g_gl.version) {
+    lua_pushstring(L, "graphlite library not loaded");
+    return 1;
+  }
+  const char* v = g_gl.version();
+  lua_pushstring(L, v ? v : "unknown");
+  return 1;
+}

--- a/ext/graphlite/lunet_graphlite.h
+++ b/ext/graphlite/lunet_graphlite.h
@@ -1,0 +1,13 @@
+#ifndef LUNET_GRAPHLITE_H
+#define LUNET_GRAPHLITE_H
+
+#include "lunet_lua.h"
+
+int lunet_graphlite_open(lua_State* L);
+int lunet_graphlite_close(lua_State* L);
+int lunet_graphlite_query(lua_State* L);
+int lunet_graphlite_create_session(lua_State* L);
+int lunet_graphlite_close_session(lua_State* L);
+int lunet_graphlite_version(lua_State* L);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -27,6 +27,10 @@
 #include "httpc.h"
 #endif
 
+#ifdef LUNET_GRAPHLITE
+#include "lunet_graphlite.h"
+#endif
+
 static char *lunet_resolve_executable_path(const char *argv0) {
 #if defined(_WIN32)
   return _fullpath(NULL, argv0, 0);
@@ -167,6 +171,26 @@ LUNET_API int luaopen_lunet_httpc(lua_State *L) {
   lunet_init_once();
   set_default_luaL(L);
   return lunet_open_httpc(L);
+}
+#endif
+
+#if defined(LUNET_GRAPHLITE)
+static int lunet_open_graphlite(lua_State *L) {
+  luaL_Reg funcs[] = {{"open", lunet_graphlite_open},
+                      {"close", lunet_graphlite_close},
+                      {"query", lunet_graphlite_query},
+                      {"create_session", lunet_graphlite_create_session},
+                      {"close_session", lunet_graphlite_close_session},
+                      {"version", lunet_graphlite_version},
+                      {NULL, NULL}};
+  luaL_newlib(L, funcs);
+  return 1;
+}
+
+LUNET_API int luaopen_lunet_graphlite(lua_State *L) {
+  lunet_init_once();
+  set_default_luaL(L);
+  return lunet_open_graphlite(L);
 }
 #endif
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -1025,3 +1025,191 @@ task("jsonic-smoke")
         os.execv(runner, {"test/smoke_jsonic.lua"})
     end)
 task_end()
+
+-- =============================================================================
+-- GraphLite extension (Rust FFI, vendored from source, optional)
+-- =============================================================================
+-- Build:   xmake build-graphlite
+-- Smoke:   xmake graphlite-smoke
+-- GraphLite has no official platform packages, so unlike ngx_shared/jsonic
+-- (whose Rust source lives in-repo under ext/), the graphlite-ffi crate is
+-- built from a pinned upstream commit that xmake clones on demand into
+-- .tmp/graphlite-vendor/. The lunet-graphlite C module (ext/graphlite/) then
+-- dlopen()s the resulting shared library at runtime.
+
+-- Pinned upstream commit for GraphLite
+local GRAPHLITE_COMMIT = "a370a1c909642688130eccfd57c74b6508dcaea5"
+local GRAPHLITE_REPO   = "https://github.com/GraphLite-AI/GraphLite.git"
+local GRAPHLITE_RUST_TOOLCHAIN = "1.87.0"
+
+-- GraphLite GQL driver: require("lunet.graphlite")
+target("lunet-graphlite")
+    set_default(false)
+    set_kind("shared")
+    add_rules("lunet.c_safety_lint")
+    set_prefixname("")
+    set_basename("graphlite")
+    set_targetdir("$(builddir)/$(plat)/$(arch)/$(mode)/lunet")
+    if is_plat("windows") then
+        set_extension(".dll")
+    else
+        set_extension(".so")
+    end
+
+    add_files(core_sources)
+    add_files("ext/graphlite/graphlite.c")
+    add_includedirs("include", "ext/graphlite", {public = true})
+    add_packages("luajit", "libuv")
+    lunet_apply_asan_flags("shared")
+    lunet_apply_easy_memory()
+    add_defines("LUNET_NO_MAIN", "LUNET_GRAPHLITE")
+
+    if is_plat("macosx") then
+        add_ldflags("-bundle", "-undefined", "dynamic_lookup", {force = true})
+    end
+    if is_plat("linux") then
+        add_defines("_GNU_SOURCE")
+        add_cflags("-pthread")
+        add_ldflags("-pthread")
+        add_syslinks("pthread", "dl", "m")
+    end
+    if is_plat("windows") then
+        add_cflags("/TC")
+        add_defines("LUNET_BUILDING_DLL")
+        add_syslinks("ws2_32", "iphlpapi", "userenv", "psapi", "advapi32", "user32", "shell32", "ole32", "dbghelp")
+    end
+    if has_config("lunet_trace") then
+        add_defines("LUNET_TRACE")
+    end
+    if has_config("lunet_verbose_trace") then
+        add_defines("LUNET_TRACE_VERBOSE")
+    end
+target_end()
+
+-- Helper: path to vendored GraphLite build
+local function graphlite_vendor_dir()
+    return path.join(os.projectdir(), ".tmp", "graphlite-vendor")
+end
+
+local function graphlite_ffi_lib_name()
+    if is_host("windows") then
+        return "graphlite_ffi.dll"
+    elseif is_host("macosx") then
+        return "libgraphlite_ffi.dylib"
+    else
+        return "libgraphlite_ffi.so"
+    end
+end
+
+task("build-graphlite")
+    set_menu {
+        usage = "xmake build-graphlite",
+        description = "Build the GraphLite Rust extension (ext/graphlite): clone + cargo build + compile C shim"
+    }
+    on_run(function ()
+        local vendor = graphlite_vendor_dir()
+        local src_dir = path.join(vendor, "GraphLite")
+        local logdir = path.join(os.projectdir(), lunet_new_logdir(os, "build_graphlite"))
+        print("GraphLite build logs: " .. logdir)
+
+        -- Step 1: Clone or update GraphLite repo at pinned commit
+        if not os.isdir(src_dir) then
+            os.mkdir(vendor)
+            print("Cloning GraphLite at " .. GRAPHLITE_COMMIT:sub(1, 12) .. "...")
+            lunet_exec_logged(os, logdir, "01_clone",
+                "git clone " .. GRAPHLITE_REPO .. " " .. lunet_quote(src_dir))
+        end
+
+        lunet_exec_logged(os, logdir, "02_checkout",
+            "cd " .. lunet_quote(src_dir) .. " && git fetch origin && git checkout " .. GRAPHLITE_COMMIT)
+
+        -- Step 2: Ensure Rust toolchain is available at the pinned version
+        print("Ensuring Rust toolchain " .. GRAPHLITE_RUST_TOOLCHAIN .. "...")
+        if is_host("windows") then
+            lunet_exec_logged(os, logdir, "03_rustup",
+                "rustup toolchain install " .. GRAPHLITE_RUST_TOOLCHAIN .. " && rustup default " .. GRAPHLITE_RUST_TOOLCHAIN)
+        else
+            lunet_exec_logged(os, logdir, "03_rustup",
+                "command -v rustup >/dev/null 2>&1 || curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain " .. GRAPHLITE_RUST_TOOLCHAIN .. " && "
+                .. "export PATH=\"$HOME/.cargo/bin:$PATH\" && "
+                .. "rustup toolchain install " .. GRAPHLITE_RUST_TOOLCHAIN .. " && "
+                .. "rustup default " .. GRAPHLITE_RUST_TOOLCHAIN)
+        end
+
+        -- Step 3: Build graphlite-ffi as a cdylib (shared library)
+        print("Building graphlite-ffi (release)...")
+        if is_host("windows") then
+            lunet_exec_logged(os, logdir, "04_cargo_build",
+                "cd " .. lunet_quote(src_dir) .. " && cargo build --release -p graphlite-ffi")
+        else
+            lunet_exec_logged(os, logdir, "04_cargo_build",
+                "export PATH=\"$(dirname $(rustup which rustc)):$PATH\" && cd " .. lunet_quote(src_dir) .. " && cargo build --release -p graphlite-ffi")
+        end
+
+        -- Step 4: Copy the FFI shared library to the lunet build output dir
+        local lib_name = graphlite_ffi_lib_name()
+        local cargo_out
+        if is_host("windows") then
+            cargo_out = path.join(src_dir, "target", "release", "graphlite_ffi.dll")
+        elseif is_host("macosx") then
+            cargo_out = path.join(src_dir, "target", "release", "libgraphlite_ffi.dylib")
+        else
+            cargo_out = path.join(src_dir, "target", "release", "libgraphlite_ffi.so")
+        end
+
+        if not os.isfile(cargo_out) then
+            raise("GraphLite FFI library not found at " .. cargo_out .. " — cargo build may have failed. Check " .. logdir)
+        end
+
+        -- Place the FFI lib alongside lunet modules so dlopen can find it
+        local build_dirs = os.dirs("build/**/lunet")
+        if #build_dirs == 0 then
+            local mode = get_config("mode") or "release"
+            local fallback = path.join("build", os.host(), os.arch(), mode, "lunet")
+            os.mkdir(fallback)
+            build_dirs = {fallback}
+        end
+        for _, d in ipairs(build_dirs) do
+            local dest = path.join(d, lib_name)
+            os.cp(cargo_out, dest)
+            print("Installed " .. lib_name .. " -> " .. dest)
+        end
+
+        -- Step 5: Build the lunet-graphlite C module
+        print("Building lunet-graphlite C module...")
+        os.exec("xmake build -y lunet-graphlite")
+
+        print("build-graphlite complete!")
+    end)
+task_end()
+
+task("graphlite-smoke")
+    set_menu {
+        usage = "xmake graphlite-smoke",
+        description = "Build the GraphLite extension then run the example smoke test"
+    }
+    on_run(function ()
+        os.exec("xmake build-release")
+        os.exec("xmake build-graphlite")
+        local mode = get_config("mode") or "release"
+        local runner = lunet_runner_path(mode)
+
+        -- Ensure the FFI lib is on the library search path
+        local lib_dirs = os.dirs("build/**/lunet")
+        local lib_path = ""
+        for _, d in ipairs(lib_dirs) do
+            lib_path = path.join(os.projectdir(), d) .. ":" .. lib_path
+        end
+
+        local envs = {}
+        if is_host("windows") then
+            envs.PATH = lib_path .. (os.getenv("PATH") or "")
+        elseif is_host("macosx") then
+            envs.DYLD_LIBRARY_PATH = lib_path .. (os.getenv("DYLD_LIBRARY_PATH") or "")
+        else
+            envs.LD_LIBRARY_PATH = lib_path .. (os.getenv("LD_LIBRARY_PATH") or "")
+        end
+
+        os.execv(runner, {"examples/10_graphlite_gql.lua"}, {envs = envs})
+    end)
+task_end()


### PR DESCRIPTION
## Summary

Refreshes and supersedes #101, recreated onto latest `main` and restructured
to land under `ext/` (consistent with the other extensions — sqlite3/mysql/postgres
C shims, ngx_shared/jsonic Rust FFI) instead of the original `opt/` layout, which
doesn't exist on `main`.

- `ext/graphlite/{graphlite.c,lunet_graphlite.h}` — C99 shim that `dlopen()`s a
  `graphlite-ffi` Rust cdylib at runtime, same coroutine yield/resume semantics
  as the SQLite3 driver (mutex-protected connection, `uv_work_t` dispatch).
- GraphLite has no official platform packages, so unlike the in-repo
  `ext/ngx_shared`/`ext/jsonic` Rust crates, `graphlite-ffi` is built from a
  pinned upstream commit (`GraphLite-AI/GraphLite@a370a1c`) that xmake clones
  on demand into `.tmp/graphlite-vendor/`, using a pinned Rust 1.87.0 toolchain
  (edition2024 + `is_multiple_of`).
- `xmake.lua`: `lunet-graphlite` target (compiles the C shim) +
  `build-graphlite`/`graphlite-smoke` tasks (renamed from the original
  `opt-graphlite`/`opt-graphlite-example` to match the `build-<ext>`/`<ext>-smoke`
  naming used by `ngx_shared`/`jsonic`).
- `examples/10_graphlite_gql.lua` — GQL walkthrough (schema/graph DDL, inserts,
  pattern matching with `MATCH`, `WHERE` filtering, aggregation).
- `README.md`/`README-CN.md` — Extensions section + Quick Reference entries.
- `.github/workflows/build.yml` — `graphlite` CI job (Linux/macOS only, not
  included in release archives, matching the `ngx_shared`/`jsonic` platform
  scope).

## Test plan

- [x] `xmake lint` passes (C safety lint, scans `ext/` already — no config change needed)
- [x] `xmake build lunet-graphlite` compiles and links the C shim cleanly (verified locally)
- [x] `examples/10_graphlite_gql.lua` passes LuaJIT syntax check
- [ ] CI: `graphlite` job (clone GraphLite, build Rust FFI, run smoke example) — Linux + macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lua-lunet/codesmith/lunet/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->