### PR TITLE
fix(ci): use gtimeout on macOS so the build job stops failing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,18 @@
 name: Build
+#
+# AppVeyor checks are a FALSE ALARM. Ignore them.
+#
+# The "continuous-integration/appveyor/pr" and ".../branch" checks that appear
+# red on pull requests are not this workflow and are not a real signal. The
+# AppVeyor account was deleted before its jobs were removed, so the webhooks
+# are orphaned: they report failure without ever building anything, and there
+# is no account left to switch them off. Clearing them needs a repo deepclean
+# (or a recreate), which is deferred until closer to 1.0.0.
+#
+# They are deliberately excluded from the required status checks on main. The
+# GitHub Actions jobs below are the only build signal that counts.
+#
+# This is also documented in the release quality gate in AGENTS.md.
 
 on:
   push:
@@ -425,7 +439,14 @@ jobs:
           $env:LUNET_EMBED_PROJECT_ROOT = $verify
           xmake lua bin\generate_embed_scripts.lua
           if ($LASTEXITCODE -ne 0) { throw "SDK blob generation failed" }
-          cl /nologo /std:c11 /I include /I generated /I "$env:VCPKG_ROOT\installed\x64-windows\include" examples\sdk_embed\main.c lib\lunet-static.lib /link /LIBPATH:"$env:VCPKG_ROOT\installed\x64-windows\lib" lua51.lib uv.lib zlib.lib ws2_32.lib iphlpapi.lib userenv.lib psapi.lib advapi32.lib user32.lib shell32.lib ole32.lib dbghelp.lib /OUT:sdk-embedded-app.exe
+          # /MD is required, not optional: lunet-static.lib is built against the
+          # dynamic CRT, so its objects reference __imp_ CRT symbols, and the
+          # vcpkg x64-windows triplet is dynamic too. Without /MD, cl defaults to
+          # the static CRT and the link dies with LNK2019 on __imp__fullpath,
+          # __imp_fopen, __imp_fwrite, __imp_realloc, __imp_strerror and
+          # __imp__mkdir (preceded by a wall of LNK4217/LNK4286 "defined in
+          # libucrt.lib ... is imported by" warnings, which are the tell).
+          cl /nologo /std:c11 /MD /I include /I generated /I "$env:VCPKG_ROOT\installed\x64-windows\include" examples\sdk_embed\main.c lib\lunet-static.lib /link /LIBPATH:"$env:VCPKG_ROOT\installed\x64-windows\lib" lua51.lib uv.lib zlib.lib ws2_32.lib iphlpapi.lib userenv.lib psapi.lib advapi32.lib user32.lib shell32.lib ole32.lib dbghelp.lib /OUT:sdk-embedded-app.exe
           if ($LASTEXITCODE -ne 0) { throw "SDK example compile failed" }
           & .\sdk-embedded-app.exe
           if ($LASTEXITCODE -ne 0) { throw "SDK example execution failed" }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,9 @@ jobs:
     - name: Install Dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
-        brew install pkg-config libuv luajit zlib sqlite3 libsodium curl libpq mysql-client
+        # coreutils provides gtimeout: macOS has no GNU timeout, and the
+        # "(Unix)" steps below need one. The easy-memory job already does this.
+        brew install pkg-config libuv luajit zlib sqlite3 libsodium curl libpq mysql-client coreutils
         echo "PKG_CONFIG_PATH=$(brew --prefix zlib)/lib/pkgconfig:$(brew --prefix curl)/lib/pkgconfig:$(brew --prefix libpq)/lib/pkgconfig:$(brew --prefix mysql-client)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
 
     - name: Setup vcpkg (Windows)
@@ -151,7 +153,8 @@ jobs:
       run: |
         SDK_API_TEST=$(find build -type f -name sdk-api-test | head -n 1)
         if [ -z "$SDK_API_TEST" ]; then echo "sdk-api-test not found" >&2; exit 1; fi
-        timeout 10 "$SDK_API_TEST"
+        if command -v gtimeout &>/dev/null; then TMO=gtimeout; else TMO=timeout; fi
+        $TMO 10 "$SDK_API_TEST"
 
     - name: C SDK lifecycle test (Windows)
       if: runner.os == 'Windows'
@@ -403,7 +406,8 @@ jobs:
             $(pkg-config --cflags luajit libuv zlib) \
             examples/sdk_embed/main.c lib/liblunet-static.a \
             $(pkg-config --libs luajit libuv zlib) -o sdk-embedded-app
-          timeout 10 ./sdk-embedded-app
+          if command -v gtimeout &>/dev/null; then TMO=gtimeout; else TMO=timeout; fi
+          $TMO 10 ./sdk-embedded-app
         )
 
     - name: Verify packaged SDK (Windows)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -448,8 +448,18 @@ jobs:
           # libucrt.lib ... is imported by" warnings, which are the tell).
           cl /nologo /std:c11 /MD /I include /I generated /I "$env:VCPKG_ROOT\installed\x64-windows\include" examples\sdk_embed\main.c lib\lunet-static.lib /link /LIBPATH:"$env:VCPKG_ROOT\installed\x64-windows\lib" lua51.lib uv.lib zlib.lib ws2_32.lib iphlpapi.lib userenv.lib psapi.lib advapi32.lib user32.lib shell32.lib ole32.lib dbghelp.lib /OUT:sdk-embedded-app.exe
           if ($LASTEXITCODE -ne 0) { throw "SDK example compile failed" }
+          # /MD plus the dynamic vcpkg triplet means the exe loads lua51.dll,
+          # uv.dll and zlib1.dll at runtime. They live in vcpkg's bin, not in
+          # the SDK archive, so without this the process dies before main()
+          # with STATUS_DLL_NOT_FOUND (0xC0000135) and prints nothing at all.
+          $env:PATH = "$env:VCPKG_ROOT\installed\x64-windows\bin;$env:PATH"
           & .\sdk-embedded-app.exe
-          if ($LASTEXITCODE -ne 0) { throw "SDK example execution failed" }
+          $appExit = $LASTEXITCODE
+          if ($appExit -ne 0) {
+            # Report the code: a bare "execution failed" with no stdout is
+            # indistinguishable from a loader failure, which cost a CI cycle.
+            throw ("SDK example execution failed (exit code {0} / 0x{1:X8})" -f $appExit, $appExit)
+          }
         } finally {
           Pop-Location
         }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,21 @@ Before creating or announcing a release:
    - `## Quick Start`
 4. **Verify before sign-off:** Check the published release page and confirm notes formatting plus all assets are present.
 5. **If anything is missing:** Fix workflow/release and republish before telling downstream users to consume the tag.
+6. **Ignore the AppVeyor checks.** `continuous-integration/appveyor/pr` and
+   `.../branch` are orphaned webhooks: the AppVeyor account was deleted before
+   its jobs were removed, so they report failure without building anything and
+   there is no account left to disable them. They are excluded from the
+   required status checks on `main`, and clearing them needs a repo deepclean
+   deferred until closer to 1.0.0. GitHub Actions is the only build signal.
+
+**Branch protection:** `main` requires the GitHub Actions build, embed-scripts
+and easy-memory checks across Linux/macOS/Windows, with `strict` set so a
+branch must be up to date before it merges. `Publish release` is deliberately
+*not* required, because it is skipped on non-tag pushes and a skipped required
+check would deadlock every merge. Without these, a PR with auto-merge enabled
+merges instantly and its CI jobs die at checkout with
+`couldn't find remote ref refs/pull/<n>/merge` — which is how #120 landed with
+no CI signal at all.
 
 ## Example Application
 


### PR DESCRIPTION
Fixes the macOS build leg, and doubles as the first PR exercising the newly-enabled required status checks on `main`.

## The bug

`build` → "C SDK lifecycle test (Unix)" ran `timeout 10`, but macOS ships no GNU `timeout`:

```
line 3: timeout: command not found
##[error]Process completed with exit code 127
```

`fail-fast: true` then cancelled the Windows leg, so a red macOS build also meant **no Windows result at all**. This is pre-existing — the same step failed the same way on the previous `main` run (`94546de`), before the #119 work.

It would also have produced a broken release: a failed macOS build job means no `lunet-macos.tar.gz` and no `lunet-macos-sdk.tar.gz`, against a release gate in `AGENTS.md` that requires all six archives.

## The fix

Two halves, mirroring what the `easy-memory` job already does:

- install `coreutils` in the build job's macOS deps
- select `gtimeout` when present, else `timeout`

Installing `coreutils` alone is not sufficient — brew installs it g-prefixed.

"Verify packaged SDK (macOS)" had the identical latent bug and was never reached, because the SDK lifecycle step failed first. Fixed too. The bare `timeout 10` remaining in "Verify packaged SDK (Linux)" is deliberate: that step is Linux-only, where GNU `timeout` exists.

## Why this PR also matters procedurally

`main` had no branch protection and no required checks, so PR #120 merged **one second after it was opened** — the CI jobs died at checkout with `couldn't find remote ref refs/pull/120/merge` because the merge ref vanished underneath them. That PR therefore landed with no CI signal whatsoever.

`main` now has branch protection with 8 required checks (both build legs plus Windows, `Embed scripts smoke`, and `EasyMem QA` across all platforms), `strict` so a branch must be up to date before merging, and force-push/deletion blocked. `Publish release` is deliberately *not* required, since it is skipped on non-tag pushes and a skipped required check would deadlock every merge.

This PR is expected to sit and wait for all three platforms — including the slow Windows leg — rather than merge instantly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lua-lunet/codesmith/lunet/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->