### PR TITLE
Advisory lock CAS demo over UDP

### DIFF
--- a/examples/advisory_lock_cas/Makefile
+++ b/examples/advisory_lock_cas/Makefile
@@ -1,7 +1,10 @@
-.PHONY: test-e2e clean
+.PHONY: test-e2e test-concurrent clean
 
 test-e2e:
 	bash run_demo.sh
+
+test-concurrent:
+	bash ../../test/item07_concurrent_test.sh
 
 clean:
 	rm -f .tmp/advisory_lock_*

--- a/examples/advisory_lock_cas/Makefile
+++ b/examples/advisory_lock_cas/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test-e2e clean
+
+test-e2e:
+	bash run_demo.sh
+
+clean:
+	rm -f .tmp/advisory_lock_*

--- a/examples/advisory_lock_cas/codec.lua
+++ b/examples/advisory_lock_cas/codec.lua
@@ -1,0 +1,106 @@
+-- Message codec for advisory lock CAS wire protocol
+-- Pure Lua, no external dependencies
+
+local codec = {}
+
+local function is_hex8(s)
+    return type(s) == "string" and #s == 8 and s:match("^[0-9a-fA-F]+$") ~= nil
+end
+
+local function is_hex16(s)
+    return type(s) == "string" and #s == 16 and s:match("^[0-9a-fA-F]+$") ~= nil
+end
+
+local function parse_get(rest)
+    local lock_str, msg_id = rest:match("^/locks/(%d+) (%S+)$")
+    if not lock_str then return nil, "malformed GET" end
+    local lock_id = tonumber(lock_str)
+    if not is_hex8(msg_id) then return nil, "invalid msg_id" end
+    return { type = "GET", lock_id = lock_id, msg_id = msg_id }
+end
+
+local function parse_set(rest)
+    local lock_str, token_str, holder_str, msg_id = rest:match("^/locks/(%d+) (%S+) (%d+) (%S+)$")
+    if not lock_str then return nil, "malformed SET" end
+    local lock_id = tonumber(lock_str)
+    if not is_hex16(token_str) then return nil, "invalid token" end
+    local token = tonumber(token_str, 16)
+    local holder = tonumber(holder_str)
+    if not is_hex8(msg_id) then return nil, "invalid msg_id" end
+    return { type = "SET", lock_id = lock_id, token = token, holder = holder, msg_id = msg_id }
+end
+
+local function parse_reply(rest)
+    local msg_id, status, holder_str, token_str = rest:match("^(%S+) (%S+) (%S+) (%S+)$")
+    if msg_id then
+        if not is_hex8(msg_id) then return nil, "invalid msg_id" end
+        if status ~= "OK" and status ~= "CONFLICT" then return nil, "invalid status" end
+        local holder = tonumber(holder_str)
+        if not holder then return nil, "invalid holder" end
+        if not is_hex16(token_str) then return nil, "invalid token" end
+        local token = tonumber(token_str, 16)
+        return { type = "REPLY", msg_id = msg_id, status = status, holder = holder, token = token }
+    end
+    local msg_id2, status2 = rest:match("^(%S+) (%S+)$")
+    if msg_id2 then
+        if not is_hex8(msg_id2) then return nil, "invalid msg_id" end
+        if status2 ~= "NOT_FOUND" then return nil, "invalid status" end
+        return { type = "REPLY", msg_id = msg_id2, status = status2 }
+    end
+    return nil, "malformed REPLY"
+end
+
+function codec.parse(raw)
+    if type(raw) ~= "string" then return nil, "input must be a string" end
+    local s = raw:match("^(.-)%s*$")
+    if not s or s == "" then return nil, "empty message" end
+
+    local cmd, rest = s:match("^(%S+) (.+)$")
+    if not cmd then return nil, "malformed message" end
+
+    if cmd == "GET" then
+        return parse_get(rest)
+    elseif cmd == "SET" then
+        return parse_set(rest)
+    elseif cmd == "PEER" then
+        local sub, subrest = rest:match("^(%S+) (.+)$")
+        if not sub then return nil, "malformed PEER message" end
+        if sub == "GET" then
+            local msg = parse_get(subrest)
+            if msg then msg.type = "PEER_GET" end
+            return msg
+        elseif sub == "SET" then
+            local msg = parse_set(subrest)
+            if msg then msg.type = "PEER_SET" end
+            return msg
+        else
+            return nil, "unknown PEER subcommand"
+        end
+    elseif cmd == "REPLY" then
+        return parse_reply(rest)
+    else
+        return nil, "unknown command"
+    end
+end
+
+function codec.format_reply(msg_id, status, holder, token)
+    if status == "NOT_FOUND" then
+        return string.format("REPLY %s NOT_FOUND", msg_id)
+    elseif status == "OK" or status == "CONFLICT" then
+        return string.format("REPLY %s %s %d %016x", msg_id, status, holder, token)
+    else
+        error("unknown status: " .. tostring(status))
+    end
+end
+
+function codec.format_peer(cmd, lock_id, token, holder, msg_id)
+    if cmd == "PEER_GET" then
+        return string.format("PEER GET /locks/%d %s", lock_id, msg_id)
+    elseif cmd == "PEER_SET" then
+        return string.format("PEER SET /locks/%d %016x %d %s", lock_id, token, holder, msg_id)
+    else
+        error("unknown peer command: " .. tostring(cmd))
+    end
+end
+
+return codec

--- a/examples/advisory_lock_cas/config_gen.lua
+++ b/examples/advisory_lock_cas/config_gen.lua
@@ -1,0 +1,89 @@
+#!/usr/bin/env lua
+-- Config Generator for Advisory Lock CAS Demo
+-- Discovers 4 free UDP ports and writes a Lua config file
+
+local lunet = require("lunet")
+local udp = require("lunet.udp")
+
+local function parse_args()
+    local output = ".tmp/advisory_lock_config.lua"
+    local i = 1
+    while i <= #arg do
+        if arg[i] == "--output" and arg[i + 1] then
+            output = arg[i + 1]
+            i = i + 2
+        else
+            i = i + 1
+        end
+    end
+    return output
+end
+
+local function discover_port()
+    local h, err = udp.bind("127.0.0.1", 0)
+    if not h then
+        error("failed to bind ephemeral port: " .. tostring(err))
+    end
+
+    local host, port, gerr = udp.getsockname(h)
+    if not host then
+        udp.close(h)
+        error("failed to getsockname: " .. tostring(gerr))
+    end
+
+    udp.close(h)
+
+    if port <= 1024 then
+        error("discovered port " .. port .. " is <= 1024")
+    end
+
+    return port
+end
+
+local function discover_unique_ports(count)
+    local ports = {}
+    local seen = {}
+    local attempts = 0
+    local max_attempts = count * 10
+
+    while #ports < count and attempts < max_attempts do
+        attempts = attempts + 1
+        local port = discover_port()
+        if not seen[port] then
+            seen[port] = true
+            ports[#ports + 1] = port
+        end
+    end
+
+    if #ports < count then
+        error("failed to discover " .. count .. " unique ports after " .. max_attempts .. " attempts")
+    end
+
+    return ports
+end
+
+local function write_config(output_path, ports)
+    local dir = output_path:match("(.+)/[^/]+$")
+    if dir then
+        os.execute("mkdir -p " .. dir)
+    end
+
+    local f, err = io.open(output_path, "w")
+    if not f then
+        error("failed to open output file: " .. tostring(err))
+    end
+
+    f:write("return {\n")
+    f:write("  hi = { client_port = " .. ports[1] .. ", peer_listen_port = " .. ports[2] .. ', host = "127.0.0.1" },\n')
+    f:write("  lo = { client_port = " .. ports[3] .. ", peer_listen_port = " .. ports[4] .. ', host = "127.0.0.1" }\n')
+    f:write("}\n")
+
+    f:close()
+end
+
+lunet.spawn(function()
+    local output_path = parse_args()
+    local ports = discover_unique_ports(4)
+    write_config(output_path, ports)
+    os.exit(0)
+end)

--- a/examples/advisory_lock_cas/lock.lua
+++ b/examples/advisory_lock_cas/lock.lua
@@ -1,0 +1,40 @@
+local M = {}
+
+function M.new()
+    return {}
+end
+
+function M.pack_token(lock_id, holder)
+    return lock_id * 0x100000000ULL + holder
+end
+
+function M.unpack_token(token)
+    local lock_id = tonumber(token / 0x100000000ULL)
+    local holder = tonumber(token % 0x100000000ULL)
+    return lock_id, holder
+end
+
+function M.get(tbl, lock_id)
+    local entry = tbl[lock_id]
+    if entry then
+        return entry.holder, entry.token
+    end
+    return 0, M.pack_token(lock_id, 0)
+end
+
+function M.cas(tbl, lock_id, expected_token, new_holder)
+    local entry = tbl[lock_id]
+    if not entry then
+        local new_token = M.pack_token(lock_id, new_holder)
+        tbl[lock_id] = { holder = new_holder, token = new_token }
+        return true, new_token
+    end
+    if entry.token == expected_token then
+        local new_token = M.pack_token(lock_id, new_holder)
+        tbl[lock_id] = { holder = new_holder, token = new_token }
+        return true, new_token
+    end
+    return false, entry.token
+end
+
+return M

--- a/examples/advisory_lock_cas/node.lua
+++ b/examples/advisory_lock_cas/node.lua
@@ -51,7 +51,9 @@ lunet.spawn(function()
 
     local client_sock, cerr = udp.bind(host, client_port)
     if not client_sock then
-        io.stderr:write("Error: failed to bind client_sock on " .. host .. ":" .. client_port .. ": " .. tostring(cerr) .. "\n")
+        io.stderr:write("Error: failed to bind client_sock on "
+            .. host .. ":" .. client_port .. ": "
+            .. tostring(cerr) .. "\n")
         os.exit(1)
     end
 

--- a/examples/advisory_lock_cas/node.lua
+++ b/examples/advisory_lock_cas/node.lua
@@ -1,0 +1,81 @@
+#!/usr/bin/env lua
+-- Node Process Skeleton for Advisory Lock CAS Demo
+-- Parses CLI args, reads config, binds UDP sockets, signals readiness
+
+local lunet = require("lunet")
+local udp = require("lunet.udp")
+
+local function usage()
+    io.stderr:write("Usage: node.lua --hi|--lo <config_path>\n")
+    os.exit(1)
+end
+
+local function parse_args()
+    if #arg ~= 2 then usage() end
+    local role_flag = arg[1]
+    local config_path = arg[2]
+
+    local role
+    if role_flag == "--hi" then
+        role = "hi"
+    elseif role_flag == "--lo" then
+        role = "lo"
+    else
+        io.stderr:write("Error: unknown flag '" .. role_flag .. "', expected --hi or --lo\n")
+        os.exit(1)
+    end
+
+    return role, config_path
+end
+
+local script_dir = debug.getinfo(1, "S").source:match("^@(.+)/[^/]+$") or "."
+
+lunet.spawn(function()
+    local role, config_path = parse_args()
+
+    local config = dofile(config_path)
+    if type(config) ~= "table" or type(config[role]) ~= "table" then
+        io.stderr:write("Error: invalid config\n")
+        os.exit(1)
+    end
+
+    local my = config[role]
+    local client_port = my.client_port
+    local peer_listen_port = my.peer_listen_port
+    local host = my.host or "127.0.0.1"
+
+    local client_sock, cerr = udp.bind(host, client_port)
+    if not client_sock then
+        io.stderr:write("Error: failed to bind client_sock on " .. host .. ":" .. client_port .. ": " .. tostring(cerr) .. "\n")
+        os.exit(1)
+    end
+
+    local peer_sock, perr = udp.bind(host, 0)
+    if not peer_sock then
+        io.stderr:write("Error: failed to bind peer_sock: " .. tostring(perr) .. "\n")
+        udp.close(client_sock)
+        os.exit(1)
+    end
+
+    local peer_listen_sock, plerr = udp.bind(host, peer_listen_port)
+    if not peer_listen_sock then
+        io.stderr:write("Error: failed to bind peer_listen_sock on " .. host .. ":" .. peer_listen_port .. ": " .. tostring(plerr) .. "\n")
+        udp.close(client_sock)
+        udp.close(peer_sock)
+        os.exit(1)
+    end
+
+    local ready_path = ".tmp/advisory_lock_node_" .. role .. "_ready"
+    local rf = io.open(ready_path, "w")
+    if rf then
+        rf:write("ready\n")
+        rf:close()
+    end
+
+    print("READY role=" .. role .. " client_port=" .. client_port .. " peer_listen_port=" .. peer_listen_port)
+    io.flush()
+
+    while true do
+        lunet.sleep(1)
+    end
+end)

--- a/examples/advisory_lock_cas/node.lua
+++ b/examples/advisory_lock_cas/node.lua
@@ -1,9 +1,13 @@
 #!/usr/bin/env lua
--- Node Process Skeleton for Advisory Lock CAS Demo
--- Parses CLI args, reads config, binds UDP sockets, signals readiness
+-- Node Process for Advisory Lock CAS Demo
+-- Parses CLI args, reads config, binds UDP sockets, runs client and peer handlers
 
 local lunet = require("lunet")
 local udp = require("lunet.udp")
+
+local script_dir = debug.getinfo(1, "S").source:match("^@(.+)/[^/]+$") or "."
+local lock = dofile(script_dir .. "/lock.lua")
+local codec = dofile(script_dir .. "/codec.lua")
 
 local function usage()
     io.stderr:write("Usage: node.lua --hi|--lo <config_path>\n")
@@ -28,8 +32,6 @@ local function parse_args()
     return role, config_path
 end
 
-local script_dir = debug.getinfo(1, "S").source:match("^@(.+)/[^/]+$") or "."
-
 lunet.spawn(function()
     local role, config_path = parse_args()
 
@@ -40,6 +42,9 @@ lunet.spawn(function()
     end
 
     local my = config[role]
+    local peer_role = (role == "hi") and "lo" or "hi"
+    local peer = config[peer_role]
+
     local client_port = my.client_port
     local peer_listen_port = my.peer_listen_port
     local host = my.host or "127.0.0.1"
@@ -75,7 +80,104 @@ lunet.spawn(function()
     print("READY role=" .. role .. " client_port=" .. client_port .. " peer_listen_port=" .. peer_listen_port)
     io.flush()
 
-    while true do
-        lunet.sleep(1)
-    end
+    local lock_table = lock.new()
+    local peer_listen_port_remote = peer.peer_listen_port
+
+    lunet.spawn(function()
+        while true do
+            local data, rhost, rport = udp.recv(client_sock)
+            if not data then
+                print("[" .. role .. "] client_handler: socket closed, exiting")
+                break
+            end
+
+            local msg = codec.parse(data)
+            if not msg then
+                print("[" .. role .. "] client_handler: failed to parse message")
+                goto continue
+            end
+
+            if msg.type == "GET" then
+                local holder, token = lock.get(lock_table, msg.lock_id)
+                local reply = codec.format_reply(msg.msg_id, "OK", holder, token)
+                udp.send(client_sock, rhost, rport, reply)
+                print("[" .. role .. "] client_handler GET lock=" .. msg.lock_id .. " result=ok holder=" .. holder)
+            elseif msg.type == "SET" then
+                local success, new_token = lock.cas(lock_table, msg.lock_id, msg.token, msg.holder)
+                if not success then
+                    local holder, _ = lock.get(lock_table, msg.lock_id)
+                    local reply = codec.format_reply(msg.msg_id, "CONFLICT", holder, new_token)
+                    udp.send(client_sock, rhost, rport, reply)
+                    print("[" .. role .. "] client_handler SET lock=" .. msg.lock_id .. " result=conflict (local)")
+                    goto continue
+                end
+
+                local peer_msg = codec.format_peer("PEER_SET", msg.lock_id, msg.token, msg.holder, msg.msg_id)
+                udp.send(peer_sock, host, peer_listen_port_remote, peer_msg)
+
+                local peer_data, _, _ = udp.recv(peer_sock)
+                local peer_reply = peer_data and codec.parse(peer_data)
+
+                if peer_reply and peer_reply.status == "OK" then
+                    local reply = codec.format_reply(msg.msg_id, "OK", msg.holder, new_token)
+                    udp.send(client_sock, rhost, rport, reply)
+                    print("[" .. role .. "] client_handler SET lock=" .. msg.lock_id .. " result=ok (peer confirmed)")
+                else
+                    if peer_reply then
+                        lock_table[msg.lock_id] = { holder = peer_reply.holder, token = peer_reply.token }
+                        local reply = codec.format_reply(msg.msg_id, "CONFLICT", peer_reply.holder, peer_reply.token)
+                        udp.send(client_sock, rhost, rport, reply)
+                        print("[" .. role .. "] client_handler SET lock=" .. msg.lock_id .. " result=conflict (peer disagreed)")
+                    else
+                        local reply = codec.format_reply(msg.msg_id, "CONFLICT", 0, 0)
+                        udp.send(client_sock, rhost, rport, reply)
+                        print("[" .. role .. "] client_handler SET lock=" .. msg.lock_id .. " result=conflict (peer no reply)")
+                    end
+                end
+            else
+                print("[" .. role .. "] client_handler: unknown message type: " .. tostring(msg.type))
+            end
+
+            ::continue::
+        end
+    end)
+
+    lunet.spawn(function()
+        while true do
+            local data, rhost, rport = udp.recv(peer_listen_sock)
+            if not data then
+                print("[" .. role .. "] peer_handler: socket closed, exiting")
+                break
+            end
+
+            local msg = codec.parse(data)
+            if not msg then
+                print("[" .. role .. "] peer_handler: failed to parse message")
+                goto continue
+            end
+
+            if msg.type == "PEER_GET" then
+                local holder, token = lock.get(lock_table, msg.lock_id)
+                local reply = codec.format_reply(msg.msg_id, "OK", holder, token)
+                udp.send(peer_listen_sock, rhost, rport, reply)
+                print("[" .. role .. "] peer_handler PEER_GET lock=" .. msg.lock_id .. " result=ok holder=" .. holder)
+            elseif msg.type == "PEER_SET" then
+                local success, new_token = lock.cas(lock_table, msg.lock_id, msg.token, msg.holder)
+                if success then
+                    local reply = codec.format_reply(msg.msg_id, "OK", msg.holder, new_token)
+                    udp.send(peer_listen_sock, rhost, rport, reply)
+                    print("[" .. role .. "] peer_handler PEER_SET lock=" .. msg.lock_id .. " result=ok")
+                else
+                    local holder, _ = lock.get(lock_table, msg.lock_id)
+                    local reply = codec.format_reply(msg.msg_id, "CONFLICT", holder, new_token)
+                    udp.send(peer_listen_sock, rhost, rport, reply)
+                    print("[" .. role .. "] peer_handler PEER_SET lock=" .. msg.lock_id .. " result=conflict")
+                end
+            else
+                print("[" .. role .. "] peer_handler: unknown message type: " .. tostring(msg.type))
+            end
+
+            ::continue::
+        end
+    end)
 end)

--- a/examples/advisory_lock_cas/node.lua
+++ b/examples/advisory_lock_cas/node.lua
@@ -64,7 +64,9 @@ lunet.spawn(function()
 
     local peer_listen_sock, plerr = udp.bind(host, peer_listen_port)
     if not peer_listen_sock then
-        io.stderr:write("Error: failed to bind peer_listen_sock on " .. host .. ":" .. peer_listen_port .. ": " .. tostring(plerr) .. "\n")
+        io.stderr:write("Error: failed to bind peer_listen_sock on "
+            .. host .. ":" .. peer_listen_port .. ": "
+            .. tostring(plerr) .. "\n")
         udp.close(client_sock)
         udp.close(peer_sock)
         os.exit(1)
@@ -127,11 +129,13 @@ lunet.spawn(function()
                         lock_table[msg.lock_id] = { holder = peer_reply.holder, token = peer_reply.token }
                         local reply = codec.format_reply(msg.msg_id, "CONFLICT", peer_reply.holder, peer_reply.token)
                         udp.send(client_sock, rhost, rport, reply)
-                        print("[" .. role .. "] client_handler SET lock=" .. msg.lock_id .. " result=conflict (peer disagreed)")
+                        print("[" .. role .. "] client_handler SET lock=" .. msg.lock_id
+                            .. " result=conflict (peer disagreed)")
                     else
                         local reply = codec.format_reply(msg.msg_id, "CONFLICT", 0, 0)
                         udp.send(client_sock, rhost, rport, reply)
-                        print("[" .. role .. "] client_handler SET lock=" .. msg.lock_id .. " result=conflict (peer no reply)")
+                        print("[" .. role .. "] client_handler SET lock=" .. msg.lock_id
+                            .. " result=conflict (peer no reply)")
                     end
                 end
             else

--- a/examples/advisory_lock_cas/run_demo.sh
+++ b/examples/advisory_lock_cas/run_demo.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+LOGDIR=".tmp/logs/$TIMESTAMP"
+mkdir -p "$LOGDIR" ".tmp"
+
+LUNET_BIN=$(find build -path '*/release/lunet-run' -type f | head -1)
+if [[ -z "$LUNET_BIN" ]]; then
+  echo "FAIL: lunet-run not found (build it first)" >&2
+  exit 1
+fi
+
+CONFIG=".tmp/advisory_lock_config.lua"
+READY_HI=".tmp/advisory_lock_node_hi_ready"
+READY_LO=".tmp/advisory_lock_node_lo_ready"
+TEST_CLIENT="test/item05_test_client.lua"
+
+rm -f "$READY_HI" "$READY_LO" "$CONFIG"
+
+cleanup() {
+    if [[ -n "${HI_PID:-}" ]] && kill -0 "$HI_PID" 2>/dev/null; then
+        kill -TERM "$HI_PID" 2>/dev/null || true
+        wait "$HI_PID" 2>/dev/null || true
+    fi
+    if [[ -n "${LO_PID:-}" ]] && kill -0 "$LO_PID" 2>/dev/null; then
+        kill -TERM "$LO_PID" 2>/dev/null || true
+        wait "$LO_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+echo "--- Generating config ---"
+timeout 10 "$LUNET_BIN" examples/advisory_lock_cas/config_gen.lua --output "$CONFIG"
+if [[ ! -f "$CONFIG" ]]; then
+    echo "FAIL: config file not created" >&2
+    exit 1
+fi
+
+echo "--- Starting HI node ---"
+timeout 30 "$LUNET_BIN" examples/advisory_lock_cas/node.lua --hi "$CONFIG" \
+    > "$LOGDIR/node_hi.log" 2>&1 &
+HI_PID=$!
+
+echo "--- Waiting for HI ready (5s) ---"
+for i in $(seq 1 50); do
+    [[ -f "$READY_HI" ]] && break
+    kill -0 "$HI_PID" 2>/dev/null || { echo "FAIL: HI node exited prematurely"; exit 1; }
+    sleep 0.1
+done
+[[ -f "$READY_HI" ]] || { echo "FAIL: Hi not ready"; exit 1; }
+
+echo "--- Starting LO node ---"
+timeout 30 "$LUNET_BIN" examples/advisory_lock_cas/node.lua --lo "$CONFIG" \
+    > "$LOGDIR/node_lo.log" 2>&1 &
+LO_PID=$!
+
+echo "--- Waiting for LO ready (5s) ---"
+for i in $(seq 1 50); do
+    [[ -f "$READY_LO" ]] && break
+    kill -0 "$LO_PID" 2>/dev/null || { echo "FAIL: LO node exited prematurely"; exit 1; }
+    sleep 0.1
+done
+[[ -f "$READY_LO" ]] || { echo "FAIL: Lo not ready"; exit 1; }
+
+echo "--- Running test client ---"
+set +e
+timeout 15 "$LUNET_BIN" "$TEST_CLIENT" 2>&1
+CLIENT_EXIT=$?
+set -e
+
+if [[ "$CLIENT_EXIT" -ne 0 ]]; then
+    echo "FAIL: test client exited with code $CLIENT_EXIT" >&2
+    echo "--- HI node log ---" >&2
+    cat "$LOGDIR/node_hi.log" >&2
+    echo "--- LO node log ---" >&2
+    cat "$LOGDIR/node_lo.log" >&2
+    exit 1
+fi
+
+echo "PASS: E2E test passed"
+exit 0

--- a/include/lunet.h
+++ b/include/lunet.h
@@ -70,6 +70,10 @@ LUNET_API int lunet_runtime_run_embedded(lunet_runtime_t *runtime,
  * successful init, even when the run failed. */
 LUNET_API void lunet_runtime_shutdown(lunet_runtime_t *runtime);
 
+/* Get the Lua state from the runtime. Returns NULL if runtime is NULL.
+ * Used by main.c to set up globals like 'arg' before running scripts. */
+LUNET_API void *lunet_runtime_get_lua_state(lunet_runtime_t *runtime);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/udp.h
+++ b/include/udp.h
@@ -7,6 +7,7 @@ int lunet_udp_bind(lua_State *L);
 int lunet_udp_send(lua_State *L);
 int lunet_udp_recv(lua_State *L);
 int lunet_udp_close(lua_State *L);
+int lunet_udp_getsockname(lua_State *L);
 
 #ifdef LUNET_TRACE
 void lunet_udp_trace_summary(void);

--- a/src/lunet.c
+++ b/src/lunet.c
@@ -62,6 +62,7 @@ int lunet_open_udp(lua_State *L) {
                       {"send", lunet_udp_send},
                       {"recv", lunet_udp_recv},
                       {"close", lunet_udp_close},
+                      {"getsockname", lunet_udp_getsockname},
                       {NULL, NULL}};
   luaL_newlib(L, funcs);
   return 1;
@@ -488,4 +489,11 @@ void lunet_runtime_shutdown(lunet_runtime_t *runtime) {
 #endif
   g_active_runtime = NULL;
   free(runtime);
+}
+
+void *lunet_runtime_get_lua_state(lunet_runtime_t *runtime) {
+  if (!runtime) {
+    return NULL;
+  }
+  return runtime->L;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "lunet.h"
+#include "lunet_lua.h"
 
 #ifdef LUNET_EMBED_SCRIPTS
 #include "embed_scripts_blob.h"
@@ -49,6 +50,17 @@ int main(int argc, char **argv) {
   if (lunet_runtime_init(&runtime, &options, error, sizeof(error)) != 0) {
     fprintf(stderr, "Error: %s\n", error);
     return 1;
+  }
+
+  /* Set up the arg global for the Lua script */
+  lua_State *L = (lua_State *)lunet_runtime_get_lua_state(runtime);
+  if (L) {
+    lua_newtable(L);
+    for (int i = script_index; i < argc; i++) {
+      lua_pushstring(L, argv[i]);
+      lua_rawseti(L, -2, i - script_index);
+    }
+    lua_setglobal(L, "arg");
   }
 
 #ifdef LUNET_EMBED_SCRIPTS

--- a/src/udp.c
+++ b/src/udp.c
@@ -503,6 +503,51 @@ int lunet_udp_recv(lua_State *co) {
   return 3;
 }
 
+int lunet_udp_getsockname(lua_State *L) {
+  udp_ctx_t *ctx = (udp_ctx_t *)lua_touserdata(L, 1);
+  if (ctx == NULL) {
+    lua_pushnil(L);
+    lua_pushnil(L);
+    lua_pushstring(L, "invalid udp handle");
+    return 3;
+  }
+
+  struct sockaddr_storage addr;
+  int namelen = sizeof(addr);
+  memset(&addr, 0, sizeof(addr));
+
+  int ret = uv_udp_getsockname(&ctx->handle, (struct sockaddr *)&addr, &namelen);
+  if (ret < 0) {
+    lua_pushnil(L);
+    lua_pushnil(L);
+    lua_pushfstring(L, "failed to getsockname: %s", uv_strerror(ret));
+    return 3;
+  }
+
+  char host[INET6_ADDRSTRLEN];
+  int port = 0;
+
+  if (addr.ss_family == AF_INET) {
+    struct sockaddr_in *a4 = (struct sockaddr_in *)&addr;
+    uv_ip4_name(a4, host, sizeof(host));
+    port = ntohs(a4->sin_port);
+  } else if (addr.ss_family == AF_INET6) {
+    struct sockaddr_in6 *a6 = (struct sockaddr_in6 *)&addr;
+    uv_ip6_name(a6, host, sizeof(host));
+    port = ntohs(a6->sin6_port);
+  } else {
+    lua_pushnil(L);
+    lua_pushnil(L);
+    lua_pushstring(L, "unknown address family");
+    return 3;
+  }
+
+  lua_pushstring(L, host);
+  lua_pushinteger(L, port);
+  lua_pushnil(L);
+  return 3;
+}
+
 int lunet_udp_close(lua_State *L) {
   if (lunet_ensure_coroutine(L, "udp.close") != 0) return 2;
 

--- a/test/item01_config_gen_test.lua
+++ b/test/item01_config_gen_test.lua
@@ -1,0 +1,122 @@
+#!/usr/bin/env lua
+-- Test for Item 01: Config Generator
+-- Tests that config_gen.lua discovers ports and writes valid Lua config
+
+local lunet = require("lunet")
+local udp = require("lunet.udp")
+
+local function test_config_gen()
+    local output_path = ".tmp/test_advisory_lock_config.lua"
+    local script_path = "examples/advisory_lock_cas/config_gen.lua"
+
+    -- Clean up any existing output
+    os.remove(output_path)
+
+    -- Run config_gen.lua
+    local cmd = string.format("./build/macosx/arm64/release/lunet-run %s --output %s", script_path, output_path)
+    local exit_code = os.execute(cmd)
+
+    -- Check exit code
+    if exit_code ~= 0 then
+        io.stderr:write("FAIL: config_gen.lua exited with code " .. tostring(exit_code) .. "\n")
+        os.exit(1)
+    end
+
+    -- Check output file exists
+    local f = io.open(output_path, "r")
+    if not f then
+        io.stderr:write("FAIL: output file does not exist at " .. output_path .. "\n")
+        os.exit(1)
+    end
+    f:close()
+
+    -- Load the config via dofile
+    local config = dofile(output_path)
+    if type(config) ~= "table" then
+        io.stderr:write("FAIL: config is not a table\n")
+        os.exit(1)
+    end
+
+    -- Check structure
+    if type(config.hi) ~= "table" then
+        io.stderr:write("FAIL: config.hi is not a table\n")
+        os.exit(1)
+    end
+    if type(config.lo) ~= "table" then
+        io.stderr:write("FAIL: config.lo is not a table\n")
+        os.exit(1)
+    end
+
+    -- Check required fields exist
+    local required_fields = {"client_port", "peer_listen_port", "host"}
+    for _, field in ipairs(required_fields) do
+        if config.hi[field] == nil then
+            io.stderr:write("FAIL: config.hi." .. field .. " is nil\n")
+            os.exit(1)
+        end
+        if config.lo[field] == nil then
+            io.stderr:write("FAIL: config.lo." .. field .. " is nil\n")
+            os.exit(1)
+        end
+    end
+
+    -- Check ports are integers > 1024
+    local ports = {
+        config.hi.client_port,
+        config.hi.peer_listen_port,
+        config.lo.client_port,
+        config.lo.peer_listen_port
+    }
+
+    for i, port in ipairs(ports) do
+        if type(port) ~= "number" then
+            io.stderr:write("FAIL: port " .. i .. " is not a number\n")
+            os.exit(1)
+        end
+        if math.floor(port) ~= port then
+            io.stderr:write("FAIL: port " .. i .. " is not an integer\n")
+            os.exit(1)
+        end
+        if port <= 1024 then
+            io.stderr:write("FAIL: port " .. i .. " is <= 1024 (got " .. port .. ")\n")
+            os.exit(1)
+        end
+    end
+
+    -- Check all 4 ports are different
+    local seen = {}
+    for i, port in ipairs(ports) do
+        if seen[port] then
+            io.stderr:write("FAIL: duplicate port " .. port .. "\n")
+            os.exit(1)
+        end
+        seen[port] = true
+    end
+
+    -- Check host is "127.0.0.1"
+    if config.hi.host ~= "127.0.0.1" then
+        io.stderr:write("FAIL: config.hi.host is not '127.0.0.1' (got '" .. tostring(config.hi.host) .. "')\n")
+        os.exit(1)
+    end
+    if config.lo.host ~= "127.0.0.1" then
+        io.stderr:write("FAIL: config.lo.host is not '127.0.0.1' (got '" .. tostring(config.lo.host) .. "')\n")
+        os.exit(1)
+    end
+
+    -- Verify ports are actually free (can bind to them)
+    lunet.spawn(function()
+        for i, port in ipairs(ports) do
+            local h, err = udp.bind("127.0.0.1", port)
+            if not h then
+                io.stderr:write("FAIL: port " .. port .. " is not free: " .. tostring(err) .. "\n")
+                os.exit(1)
+            end
+            udp.close(h)
+        end
+    end)
+
+    print("PASS: all config_gen tests passed")
+    os.exit(0)
+end
+
+test_config_gen()

--- a/test/item01_config_gen_test.lua
+++ b/test/item01_config_gen_test.lua
@@ -85,7 +85,7 @@ local function test_config_gen()
 
     -- Check all 4 ports are different
     local seen = {}
-    for i, port in ipairs(ports) do
+    for _, port in ipairs(ports) do
         if seen[port] then
             io.stderr:write("FAIL: duplicate port " .. port .. "\n")
             os.exit(1)
@@ -105,7 +105,7 @@ local function test_config_gen()
 
     -- Verify ports are actually free (can bind to them)
     lunet.spawn(function()
-        for i, port in ipairs(ports) do
+    for _, port in ipairs(ports) do
             local h, err = udp.bind("127.0.0.1", port)
             if not h then
                 io.stderr:write("FAIL: port " .. port .. " is not free: " .. tostring(err) .. "\n")

--- a/test/item02_lock_table_test.lua
+++ b/test/item02_lock_table_test.lua
@@ -102,7 +102,7 @@ end
 local function test_max_u32_lock_id()
     local tbl = lock.new()
     local maxu32 = 4294967295
-    local ok, t = lock.cas(tbl, maxu32, lock.pack_token(maxu32, 0), 1)
+    local ok, _ = lock.cas(tbl, maxu32, lock.pack_token(maxu32, 0), 1)
     assert_eq(ok, true, "CAS max u32 lock_id succeeds")
     local holder, token = lock.get(tbl, maxu32)
     assert_eq(holder, 1, "max u32 lock_id holder")
@@ -112,7 +112,7 @@ end
 local function test_max_u32_holder()
     local tbl = lock.new()
     local maxu32 = 4294967295
-    local ok, t = lock.cas(tbl, 1, lock.pack_token(1, 0), maxu32)
+    local ok, _ = lock.cas(tbl, 1, lock.pack_token(1, 0), maxu32)
     assert_eq(ok, true, "CAS max u32 holder succeeds")
     local holder, token = lock.get(tbl, 1)
     assert_eq(holder, maxu32, "max u32 holder")

--- a/test/item02_lock_table_test.lua
+++ b/test/item02_lock_table_test.lua
@@ -1,0 +1,148 @@
+#!/usr/bin/env lua
+-- Test for Item 02: Lock Table + CAS
+-- Tests pure Lua lock table with CAS semantics
+
+local lock = dofile("examples/advisory_lock_cas/lock.lua")
+
+local function assert_eq(got, expected, msg)
+    if got ~= expected then
+        io.stderr:write(string.format("FAIL: %s: expected %s, got %s\n",
+            msg, tostring(expected), tostring(got)))
+        os.exit(1)
+    end
+end
+
+local function test_new()
+    local tbl = lock.new()
+    assert_eq(type(tbl), "table", "lock.new() returns a table")
+end
+
+local function test_pack_token()
+    assert_eq(lock.pack_token(1, 0), 4294967296ULL, "pack_token(1, 0)")
+    assert_eq(lock.pack_token(1, 7), 4294967303ULL, "pack_token(1, 7)")
+    assert_eq(lock.pack_token(0, 5), 5ULL, "pack_token(0, 5)")
+end
+
+local function test_unpack_token()
+    local lid, h = lock.unpack_token(4294967303ULL)
+    assert_eq(lid, 1, "unpack_token lock_id")
+    assert_eq(h, 7, "unpack_token holder")
+end
+
+local function test_pack_unpack_roundtrip()
+    local cases = {{1, 7}, {0, 0}, {42, 0}, {100, 200}, {4294967295, 4294967295}}
+    for _, c in ipairs(cases) do
+        local token = lock.pack_token(c[1], c[2])
+        local lid, h = lock.unpack_token(token)
+        assert_eq(lid, c[1], string.format("roundtrip lock_id for (%d, %d)", c[1], c[2]))
+        assert_eq(h, c[2], string.format("roundtrip holder for (%d, %d)", c[1], c[2]))
+    end
+end
+
+local function test_get_nonexistent()
+    local tbl = lock.new()
+    local holder, token = lock.get(tbl, 42)
+    assert_eq(holder, 0, "get nonexistent holder")
+    assert_eq(token, lock.pack_token(42, 0), "get nonexistent token")
+end
+
+local function test_cas_nonexistent()
+    local tbl = lock.new()
+    local expected_token = lock.pack_token(10, 0)
+    local ok, new_token = lock.cas(tbl, 10, expected_token, 5)
+    assert_eq(ok, true, "CAS on nonexistent succeeds")
+    assert_eq(new_token, lock.pack_token(10, 5), "CAS on nonexistent new_token")
+    local holder, token = lock.get(tbl, 10)
+    assert_eq(holder, 5, "after CAS nonexistent holder")
+    assert_eq(token, lock.pack_token(10, 5), "after CAS nonexistent token")
+end
+
+local function test_cas_correct_token()
+    local tbl = lock.new()
+    lock.cas(tbl, 10, lock.pack_token(10, 0), 5)
+    local ok, new_token = lock.cas(tbl, 10, lock.pack_token(10, 5), 99)
+    assert_eq(ok, true, "CAS with correct token succeeds")
+    assert_eq(new_token, lock.pack_token(10, 99), "CAS correct token new_token")
+    local holder, token = lock.get(tbl, 10)
+    assert_eq(holder, 99, "after CAS correct holder")
+    assert_eq(token, lock.pack_token(10, 99), "after CAS correct token")
+end
+
+local function test_cas_stale_token()
+    local tbl = lock.new()
+    lock.cas(tbl, 10, lock.pack_token(10, 0), 5)
+    local stale_token = lock.pack_token(10, 0)
+    local ok, current_token = lock.cas(tbl, 10, stale_token, 99)
+    assert_eq(ok, false, "CAS with stale token fails")
+    assert_eq(current_token, lock.pack_token(10, 5), "CAS stale returns current_token")
+end
+
+local function test_sequential_cas_different_locks()
+    local tbl = lock.new()
+    local ok1, t1 = lock.cas(tbl, 1, lock.pack_token(1, 0), 10)
+    local ok2, t2 = lock.cas(tbl, 2, lock.pack_token(2, 0), 20)
+    assert_eq(ok1, true, "CAS lock 1 succeeds")
+    assert_eq(ok2, true, "CAS lock 2 succeeds")
+    assert_eq(t1, lock.pack_token(1, 10), "CAS lock 1 token")
+    assert_eq(t2, lock.pack_token(2, 20), "CAS lock 2 token")
+    local h1, _ = lock.get(tbl, 1)
+    local h2, _ = lock.get(tbl, 2)
+    assert_eq(h1, 10, "lock 1 holder")
+    assert_eq(h2, 20, "lock 2 holder")
+end
+
+local function test_get_after_cas()
+    local tbl = lock.new()
+    lock.cas(tbl, 42, lock.pack_token(42, 0), 77)
+    local holder, token = lock.get(tbl, 42)
+    assert_eq(holder, 77, "get after CAS holder")
+    assert_eq(token, lock.pack_token(42, 77), "get after CAS token")
+end
+
+local function test_max_u32_lock_id()
+    local tbl = lock.new()
+    local maxu32 = 4294967295
+    local ok, t = lock.cas(tbl, maxu32, lock.pack_token(maxu32, 0), 1)
+    assert_eq(ok, true, "CAS max u32 lock_id succeeds")
+    local holder, token = lock.get(tbl, maxu32)
+    assert_eq(holder, 1, "max u32 lock_id holder")
+    assert_eq(token, lock.pack_token(maxu32, 1), "max u32 lock_id token")
+end
+
+local function test_max_u32_holder()
+    local tbl = lock.new()
+    local maxu32 = 4294967295
+    local ok, t = lock.cas(tbl, 1, lock.pack_token(1, 0), maxu32)
+    assert_eq(ok, true, "CAS max u32 holder succeeds")
+    local holder, token = lock.get(tbl, 1)
+    assert_eq(holder, maxu32, "max u32 holder")
+    assert_eq(token, lock.pack_token(1, maxu32), "max u32 holder token")
+end
+
+local function test_cas_release()
+    local tbl = lock.new()
+    lock.cas(tbl, 5, lock.pack_token(5, 0), 42)
+    local ok, new_token = lock.cas(tbl, 5, lock.pack_token(5, 42), 0)
+    assert_eq(ok, true, "CAS release succeeds")
+    assert_eq(new_token, lock.pack_token(5, 0), "CAS release token")
+    local holder, token = lock.get(tbl, 5)
+    assert_eq(holder, 0, "after release holder")
+    assert_eq(token, lock.pack_token(5, 0), "after release token")
+end
+
+test_new()
+test_pack_token()
+test_unpack_token()
+test_pack_unpack_roundtrip()
+test_get_nonexistent()
+test_cas_nonexistent()
+test_cas_correct_token()
+test_cas_stale_token()
+test_sequential_cas_different_locks()
+test_get_after_cas()
+test_max_u32_lock_id()
+test_max_u32_holder()
+test_cas_release()
+
+print("PASS: all lock table + CAS tests passed")
+os.exit(0)

--- a/test/item03_message_codec_test.lua
+++ b/test/item03_message_codec_test.lua
@@ -1,0 +1,204 @@
+#!/usr/bin/env lua
+-- Test for Item 03: Message Codec
+-- Tests pure Lua codec that parses and formats wire protocol messages
+
+local codec = dofile("examples/advisory_lock_cas/codec.lua")
+
+local pass_count = 0
+
+local function assert_eq(got, expected, msg)
+    if got ~= expected then
+        io.stderr:write(string.format("FAIL: %s: expected %s, got %s\n",
+            msg, tostring(expected), tostring(got)))
+        os.exit(1)
+    end
+    pass_count = pass_count + 1
+end
+
+local function assert_nil(val, msg)
+    if val ~= nil then
+        io.stderr:write(string.format("FAIL: %s: expected nil, got %s\n",
+            msg, tostring(val)))
+        os.exit(1)
+    end
+    pass_count = pass_count + 1
+end
+
+local function assert_not_nil(val, msg)
+    if val == nil then
+        io.stderr:write(string.format("FAIL: %s: expected non-nil\n", msg))
+        os.exit(1)
+    end
+    pass_count = pass_count + 1
+end
+
+-- 1. Parse GET
+local function test_parse_get()
+    local msg = codec.parse("GET /locks/42 abc00001")
+    assert_not_nil(msg, "parse GET returns table")
+    assert_eq(msg.type, "GET", "GET type")
+    assert_eq(msg.lock_id, 42, "GET lock_id")
+    assert_eq(msg.msg_id, "abc00001", "GET msg_id")
+end
+
+-- 2. Parse SET
+local function test_parse_set()
+    local msg = codec.parse("SET /locks/7 0000000700000000 99 def00002")
+    assert_not_nil(msg, "parse SET returns table")
+    assert_eq(msg.type, "SET", "SET type")
+    assert_eq(msg.lock_id, 7, "SET lock_id")
+    assert_eq(msg.token, 0x0000000700000000, "SET token")
+    assert_eq(msg.holder, 99, "SET holder")
+    assert_eq(msg.msg_id, "def00002", "SET msg_id")
+end
+
+-- 3. Parse PEER GET
+local function test_parse_peer_get()
+    local msg = codec.parse("PEER GET /locks/42 aabbccdd")
+    assert_not_nil(msg, "parse PEER GET returns table")
+    assert_eq(msg.type, "PEER_GET", "PEER_GET type")
+    assert_eq(msg.lock_id, 42, "PEER_GET lock_id")
+    assert_eq(msg.msg_id, "aabbccdd", "PEER_GET msg_id")
+end
+
+-- 4. Parse PEER SET
+local function test_parse_peer_set()
+    local msg = codec.parse("PEER SET /locks/42 0000002A0000000F 77 eeff0011")
+    assert_not_nil(msg, "parse PEER SET returns table")
+    assert_eq(msg.type, "PEER_SET", "PEER_SET type")
+    assert_eq(msg.lock_id, 42, "PEER_SET lock_id")
+    assert_eq(msg.token, 0x0000002A0000000F, "PEER_SET token")
+    assert_eq(msg.holder, 77, "PEER_SET holder")
+    assert_eq(msg.msg_id, "eeff0011", "PEER_SET msg_id")
+end
+
+-- 5. Parse REPLY OK
+local function test_parse_reply_ok()
+    local msg = codec.parse("REPLY abc00001 OK 42 0000002A0000002A")
+    assert_not_nil(msg, "parse REPLY OK returns table")
+    assert_eq(msg.type, "REPLY", "REPLY type")
+    assert_eq(msg.status, "OK", "REPLY OK status")
+    assert_eq(msg.holder, 42, "REPLY OK holder")
+    assert_eq(msg.token, 0x0000002A0000002A, "REPLY OK token")
+    assert_eq(msg.msg_id, "abc00001", "REPLY OK msg_id")
+end
+
+-- 6. Parse REPLY CONFLICT
+local function test_parse_reply_conflict()
+    local msg = codec.parse("REPLY abc00001 CONFLICT 99 0000002A00000063")
+    assert_not_nil(msg, "parse REPLY CONFLICT returns table")
+    assert_eq(msg.type, "REPLY", "REPLY CONFLICT type")
+    assert_eq(msg.status, "CONFLICT", "REPLY CONFLICT status")
+    assert_eq(msg.holder, 99, "REPLY CONFLICT holder")
+end
+
+-- 7. Parse REPLY NOT_FOUND
+local function test_parse_reply_not_found()
+    local msg = codec.parse("REPLY abc00001 NOT_FOUND")
+    assert_not_nil(msg, "parse REPLY NOT_FOUND returns table")
+    assert_eq(msg.type, "REPLY", "REPLY NOT_FOUND type")
+    assert_eq(msg.status, "NOT_FOUND", "REPLY NOT_FOUND status")
+end
+
+-- 8. Parse garbage
+local function test_parse_garbage()
+    local msg, err = codec.parse("garbage")
+    assert_nil(msg, "garbage returns nil")
+    assert_not_nil(err, "garbage returns error")
+end
+
+-- 9. Parse incomplete GET
+local function test_parse_incomplete()
+    local msg, err = codec.parse("GET /locks/")
+    assert_nil(msg, "incomplete returns nil")
+    assert_not_nil(err, "incomplete returns error")
+end
+
+-- 10. Parse invalid token
+local function test_parse_invalid_token()
+    local msg, err = codec.parse("SET /locks/1 nothex0000000000 5 00000000")
+    assert_nil(msg, "invalid token returns nil")
+    assert_not_nil(err, "invalid token returns error")
+end
+
+-- 11. Parse bad status
+local function test_parse_bad_status()
+    local msg, err = codec.parse("REPLY 00000000 BADSTATUS 1 0000000000000001")
+    assert_nil(msg, "bad status returns nil")
+    assert_not_nil(err, "bad status returns error")
+end
+
+-- 12. format_reply OK
+local function test_format_reply_ok()
+    local s = codec.format_reply("abc00001", "OK", 42, 0x0000002A0000002A)
+    assert_eq(s, "REPLY abc00001 OK 42 0000002a0000002a", "format_reply OK")
+end
+
+-- 13. format_reply NOT_FOUND
+local function test_format_reply_not_found()
+    local s = codec.format_reply("abc00001", "NOT_FOUND")
+    assert_eq(s, "REPLY abc00001 NOT_FOUND", "format_reply NOT_FOUND")
+end
+
+-- 14. format_peer PEER_SET
+local function test_format_peer_set()
+    local s = codec.format_peer("PEER_SET", 42, 0x0000002A0000000F, 77, "eeff0011")
+    assert_eq(s, "PEER SET /locks/42 0000002a0000000f 77 eeff0011", "format_peer PEER_SET")
+end
+
+-- 15. format_peer PEER_GET
+local function test_format_peer_get()
+    local s = codec.format_peer("PEER_GET", 42, nil, nil, "abcd0001")
+    assert_eq(s, "PEER GET /locks/42 abcd0001", "format_peer PEER_GET")
+end
+
+-- 16. Roundtrip
+local function test_roundtrip()
+    local original = "REPLY abc00001 OK 42 0000002a0000002a"
+    local formatted = codec.format_reply("abc00001", "OK", 42, 0x0000002A0000002A)
+    local msg = codec.parse(formatted)
+    assert_not_nil(msg, "roundtrip parse succeeds")
+    assert_eq(msg.type, "REPLY", "roundtrip type")
+    assert_eq(msg.status, "OK", "roundtrip status")
+    assert_eq(msg.holder, 42, "roundtrip holder")
+    assert_eq(msg.msg_id, "abc00001", "roundtrip msg_id")
+end
+
+-- 17. Empty string
+local function test_parse_empty()
+    local msg, err = codec.parse("")
+    assert_nil(msg, "empty string returns nil")
+    assert_not_nil(err, "empty string returns error")
+end
+
+-- 18. Trailing whitespace
+local function test_parse_trailing_whitespace()
+    local msg = codec.parse("GET /locks/42 abc00001   ")
+    assert_not_nil(msg, "trailing whitespace parsed")
+    assert_eq(msg.type, "GET", "trailing ws type")
+    assert_eq(msg.lock_id, 42, "trailing ws lock_id")
+    assert_eq(msg.msg_id, "abc00001", "trailing ws msg_id")
+end
+
+-- Run all tests
+test_parse_get()
+test_parse_set()
+test_parse_peer_get()
+test_parse_peer_set()
+test_parse_reply_ok()
+test_parse_reply_conflict()
+test_parse_reply_not_found()
+test_parse_garbage()
+test_parse_incomplete()
+test_parse_invalid_token()
+test_parse_bad_status()
+test_format_reply_ok()
+test_format_reply_not_found()
+test_format_peer_set()
+test_format_peer_get()
+test_roundtrip()
+test_parse_empty()
+test_parse_trailing_whitespace()
+
+print(string.format("All %d assertions passed", pass_count))
+os.exit(0)

--- a/test/item03_message_codec_test.lua
+++ b/test/item03_message_codec_test.lua
@@ -154,7 +154,6 @@ end
 
 -- 16. Roundtrip
 local function test_roundtrip()
-    local original = "REPLY abc00001 OK 42 0000002a0000002a"
     local formatted = codec.format_reply("abc00001", "OK", 42, 0x0000002A0000002A)
     local msg = codec.parse(formatted)
     assert_not_nil(msg, "roundtrip parse succeeds")

--- a/test/item04_node_skeleton_test.sh
+++ b/test/item04_node_skeleton_test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Test for Item 04: Node Process Skeleton
+# Red phase: NOT YET IMPLEMENTED
+set -euo pipefail
+
+echo "NOT YET IMPLEMENTED"
+exit 1

--- a/test/item04_node_skeleton_test.sh
+++ b/test/item04_node_skeleton_test.sh
@@ -1,7 +1,153 @@
 #!/usr/bin/env bash
 # Test for Item 04: Node Process Skeleton
-# Red phase: NOT YET IMPLEMENTED
 set -euo pipefail
 
-echo "NOT YET IMPLEMENTED"
-exit 1
+LUNET_BIN="./build/macosx/arm64/release/lunet-run"
+CONFIG_GEN="examples/advisory_lock_cas/config_gen.lua"
+NODE="examples/advisory_lock_cas/node.lua"
+CONFIG=".tmp/test_item04_config.lua"
+READY_HI=".tmp/advisory_lock_node_hi_ready"
+READY_LO=".tmp/advisory_lock_node_lo_ready"
+HI_LOG=".tmp/test_item04_hi.log"
+LO_LOG=".tmp/test_item04_lo.log"
+
+FAILURES=0
+
+cleanup() {
+    if [[ -n "${HI_PID:-}" ]] && kill -0 "$HI_PID" 2>/dev/null; then
+        kill -TERM "$HI_PID" 2>/dev/null || true
+        wait "$HI_PID" 2>/dev/null || true
+    fi
+    if [[ -n "${LO_PID:-}" ]] && kill -0 "$LO_PID" 2>/dev/null; then
+        kill -TERM "$LO_PID" 2>/dev/null || true
+        wait "$LO_PID" 2>/dev/null || true
+    fi
+    rm -f "$READY_HI" "$READY_LO" "$CONFIG" "$HI_LOG" "$LO_LOG"
+}
+trap cleanup EXIT
+
+rm -f "$READY_HI" "$READY_LO" "$CONFIG" "$HI_LOG" "$LO_LOG"
+mkdir -p .tmp
+
+echo "--- Step 1: Generate config ---"
+timeout 10 "$LUNET_BIN" "$CONFIG_GEN" --output "$CONFIG"
+if [[ ! -f "$CONFIG" ]]; then
+    echo "FAIL: config file not created"
+    exit 1
+fi
+echo "Config generated."
+
+echo "--- Step 2: Start HI node ---"
+"$LUNET_BIN" "$NODE" --hi "$CONFIG" >"$HI_LOG" 2>&1 &
+HI_PID=$!
+
+echo "--- Step 3: Poll for HI readiness (5s timeout) ---"
+for i in $(seq 1 50); do
+    if [[ -f "$READY_HI" ]]; then break; fi
+    if ! kill -0 "$HI_PID" 2>/dev/null; then
+        echo "FAIL: HI node exited prematurely"
+        cat "$HI_LOG"
+        exit 1
+    fi
+    sleep 0.1
+done
+if [[ ! -f "$READY_HI" ]]; then
+    echo "FAIL: HI readiness file not found after 5s"
+    cat "$HI_LOG"
+    exit 1
+fi
+echo "HI node ready."
+
+echo "--- Step 4: Assert READY printed for HI ---"
+if ! grep -q "^READY role=hi " "$HI_LOG"; then
+    echo "FAIL: READY line not found in HI log"
+    cat "$HI_LOG"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "HI READY line found."
+fi
+
+echo "--- Step 5: Start LO node ---"
+"$LUNET_BIN" "$NODE" --lo "$CONFIG" >"$LO_LOG" 2>&1 &
+LO_PID=$!
+
+echo "--- Step 6: Poll for LO readiness (5s timeout) ---"
+for i in $(seq 1 50); do
+    if [[ -f "$READY_LO" ]]; then break; fi
+    if ! kill -0 "$LO_PID" 2>/dev/null; then
+        echo "FAIL: LO node exited prematurely"
+        cat "$LO_LOG"
+        exit 1
+    fi
+    sleep 0.1
+done
+if [[ ! -f "$READY_LO" ]]; then
+    echo "FAIL: LO readiness file not found after 5s"
+    cat "$LO_LOG"
+    exit 1
+fi
+echo "LO node ready."
+
+echo "--- Step 7: Send SIGTERM to both nodes ---"
+kill -TERM "$HI_PID"
+kill -TERM "$LO_PID"
+
+echo "--- Step 8: Assert both exit cleanly (0 or SIGTERM=143) ---"
+set +e
+wait "$HI_PID" 2>/dev/null
+HI_EXIT=$?
+wait "$LO_PID" 2>/dev/null
+LO_EXIT=$?
+set -e
+
+if [[ "$HI_EXIT" -ne 0 && "$HI_EXIT" -ne 143 ]]; then
+    echo "FAIL: HI node exited with code $HI_EXIT (expected 0 or 143)"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "HI node exited cleanly (code $HI_EXIT)."
+fi
+if [[ "$LO_EXIT" -ne 0 && "$LO_EXIT" -ne 143 ]]; then
+    echo "FAIL: LO node exited with code $LO_EXIT (expected 0 or 143)"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "LO node exited cleanly (code $LO_EXIT)."
+fi
+
+echo "--- Step 9: Assert no Error/FAIL in logs (excluding shell termination messages) ---"
+if grep -i "error" "$HI_LOG" 2>/dev/null | grep -v "Terminated"; then
+    echo "FAIL: Error found in HI log"
+    FAILURES=$((FAILURES + 1))
+fi
+if grep -i "error" "$LO_LOG" 2>/dev/null | grep -v "Terminated"; then
+    echo "FAIL: Error found in LO log"
+    FAILURES=$((FAILURES + 1))
+fi
+if grep -i "^FAIL" "$HI_LOG" 2>/dev/null; then
+    echo "FAIL: FAIL found in HI log"
+    FAILURES=$((FAILURES + 1))
+fi
+if grep -i "^FAIL" "$LO_LOG" 2>/dev/null; then
+    echo "FAIL: FAIL found in LO log"
+    FAILURES=$((FAILURES + 1))
+fi
+
+echo "--- Step 10: Verify ports freed ---"
+HI_CLIENT_PORT=$(sed -n 's/.*client_port=\([0-9]*\).*/\1/p' "$HI_LOG" | head -1)
+LO_CLIENT_PORT=$(sed -n 's/.*client_port=\([0-9]*\).*/\1/p' "$LO_LOG" | head -1)
+sleep 0.5
+if [[ -n "$HI_CLIENT_PORT" ]] && lsof -i :"$HI_CLIENT_PORT" 2>/dev/null | grep -q UDP; then
+    echo "FAIL: HI client port $HI_CLIENT_PORT still in use"
+    FAILURES=$((FAILURES + 1))
+fi
+if [[ -n "$LO_CLIENT_PORT" ]] && lsof -i :"$LO_CLIENT_PORT" 2>/dev/null | grep -q UDP; then
+    echo "FAIL: LO client port $LO_CLIENT_PORT still in use"
+    FAILURES=$((FAILURES + 1))
+fi
+
+if [[ "$FAILURES" -gt 0 ]]; then
+    echo "FAIL: $FAILURES check(s) failed"
+    exit 1
+fi
+
+echo "PASS: all item04 node skeleton tests passed"
+exit 0

--- a/test/item05_node_loop_test.sh
+++ b/test/item05_node_loop_test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Test for Item 05: Node Main Loop
+set -euo pipefail
+
+LUNET_BIN="./build/macosx/arm64/release/lunet-run"
+CONFIG_GEN="examples/advisory_lock_cas/config_gen.lua"
+NODE="examples/advisory_lock_cas/node.lua"
+TEST_CLIENT="test/item05_test_client.lua"
+CONFIG=".tmp/advisory_lock_config.lua"
+READY_HI=".tmp/advisory_lock_node_hi_ready"
+READY_LO=".tmp/advisory_lock_node_lo_ready"
+HI_LOG=".tmp/test_item05_hi.log"
+LO_LOG=".tmp/test_item05_lo.log"
+CLIENT_LOG=".tmp/test_item05_client.log"
+
+cleanup() {
+    if [[ -n "${HI_PID:-}" ]] && kill -0 "$HI_PID" 2>/dev/null; then
+        kill -TERM "$HI_PID" 2>/dev/null || true
+        wait "$HI_PID" 2>/dev/null || true
+    fi
+    if [[ -n "${LO_PID:-}" ]] && kill -0 "$LO_PID" 2>/dev/null; then
+        kill -TERM "$LO_PID" 2>/dev/null || true
+        wait "$LO_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+rm -f "$READY_HI" "$READY_LO" "$CONFIG" "$HI_LOG" "$LO_LOG" "$CLIENT_LOG"
+mkdir -p .tmp
+
+echo "--- Step 1: Generate config ---"
+timeout 10 "$LUNET_BIN" "$CONFIG_GEN" --output "$CONFIG"
+if [[ ! -f "$CONFIG" ]]; then
+    echo "FAIL: config file not created"
+    exit 1
+fi
+echo "Config generated."
+
+echo "--- Step 2: Start HI node ---"
+"$LUNET_BIN" "$NODE" --hi "$CONFIG" >"$HI_LOG" 2>&1 &
+HI_PID=$!
+
+echo "--- Step 3: Poll for HI readiness (5s timeout) ---"
+for i in $(seq 1 50); do
+    if [[ -f "$READY_HI" ]]; then break; fi
+    if ! kill -0 "$HI_PID" 2>/dev/null; then
+        echo "FAIL: HI node exited prematurely"
+        cat "$HI_LOG"
+        exit 1
+    fi
+    sleep 0.1
+done
+if [[ ! -f "$READY_HI" ]]; then
+    echo "FAIL: HI readiness file not found after 5s"
+    cat "$HI_LOG"
+    exit 1
+fi
+echo "HI node ready."
+
+echo "--- Step 4: Start LO node ---"
+"$LUNET_BIN" "$NODE" --lo "$CONFIG" >"$LO_LOG" 2>&1 &
+LO_PID=$!
+
+echo "--- Step 5: Poll for LO readiness (5s timeout) ---"
+for i in $(seq 1 50); do
+    if [[ -f "$READY_LO" ]]; then break; fi
+    if ! kill -0 "$LO_PID" 2>/dev/null; then
+        echo "FAIL: LO node exited prematurely"
+        cat "$LO_LOG"
+        exit 1
+    fi
+    sleep 0.1
+done
+if [[ ! -f "$READY_LO" ]]; then
+    echo "FAIL: LO readiness file not found after 5s"
+    cat "$LO_LOG"
+    exit 1
+fi
+echo "LO node ready."
+
+echo "--- Step 6: Run test client ---"
+set +e
+timeout 15 "$LUNET_BIN" "$TEST_CLIENT" >"$CLIENT_LOG" 2>&1
+CLIENT_EXIT=$?
+set -e
+
+cat "$CLIENT_LOG"
+
+if [[ "$CLIENT_EXIT" -ne 0 ]]; then
+    echo "FAIL: test client exited with code $CLIENT_EXIT"
+    echo "--- HI node log ---"
+    cat "$HI_LOG"
+    echo "--- LO node log ---"
+    cat "$LO_LOG"
+    exit 1
+fi
+
+echo "--- Step 7: Kill nodes ---"
+kill -TERM "$HI_PID" 2>/dev/null || true
+kill -TERM "$LO_PID" 2>/dev/null || true
+wait "$HI_PID" 2>/dev/null || true
+wait "$LO_PID" 2>/dev/null || true
+HI_PID=""
+LO_PID=""
+
+echo "PASS: all item05 node loop tests passed"
+exit 0

--- a/test/item05_test_client.lua
+++ b/test/item05_test_client.lua
@@ -26,7 +26,7 @@ local function send_recv(sock, target_host, target_port, msg)
         io.stderr:write("FAIL: send error: " .. tostring(err) .. "\n")
         return nil
     end
-    local data, rhost, rport = udp.recv(sock)
+    local data = udp.recv(sock)
     if not data then
         io.stderr:write("FAIL: recv returned nil\n")
         return nil

--- a/test/item05_test_client.lua
+++ b/test/item05_test_client.lua
@@ -1,0 +1,157 @@
+#!/usr/bin/env lua
+-- Test Client for Item 05: Node Main Loop
+-- Sends GET/SET messages to Hi and Lo nodes and verifies responses
+
+local lunet = require("lunet")
+local udp = require("lunet.udp")
+
+local script_dir = debug.getinfo(1, "S").source:match("^@(.+)/[^/]+$") or "."
+local config_path = ".tmp/advisory_lock_config.lua"
+
+local config = dofile(config_path)
+if type(config) ~= "table" then
+    io.stderr:write("FAIL: cannot load config\n")
+    os.exit(1)
+end
+
+local codec = dofile(script_dir .. "/../examples/advisory_lock_cas/codec.lua")
+
+local hi_client_port = config.hi.client_port
+local lo_client_port = config.lo.client_port
+local host = "127.0.0.1"
+
+local function send_recv(sock, target_host, target_port, msg)
+    local ok, err = udp.send(sock, target_host, target_port, msg)
+    if not ok then
+        io.stderr:write("FAIL: send error: " .. tostring(err) .. "\n")
+        return nil
+    end
+    local data, rhost, rport = udp.recv(sock)
+    if not data then
+        io.stderr:write("FAIL: recv returned nil\n")
+        return nil
+    end
+    return codec.parse(data)
+end
+
+local function make_msg_id()
+    return string.format("%08x", math.random(0, 0xFFFFFFFF))
+end
+
+lunet.spawn(function()
+    local sock, err = udp.bind(host, 0)
+    if not sock then
+        io.stderr:write("FAIL: cannot bind client socket: " .. tostring(err) .. "\n")
+        os.exit(1)
+    end
+
+    local failures = 0
+
+    -- Test a: GET lock 1 from Hi -> OK holder=0
+    do
+        local msg_id = make_msg_id()
+        local msg = string.format("GET /locks/1 %s", msg_id)
+        print("[test] sending GET lock=1 to Hi")
+        local reply = send_recv(sock, host, hi_client_port, msg)
+        if not reply then
+            io.stderr:write("FAIL: test a: no reply\n")
+            failures = failures + 1
+        elseif reply.type ~= "REPLY" or reply.status ~= "OK" or reply.holder ~= 0 then
+            io.stderr:write(string.format("FAIL: test a: expected OK holder=0, got status=%s holder=%s\n",
+                tostring(reply.status), tostring(reply.holder)))
+            failures = failures + 1
+        else
+            print("[test] test a PASS: GET lock=1 from Hi -> OK holder=0")
+        end
+    end
+
+    -- Test b: SET lock 1 to holder=42 via Hi -> OK
+    local set_token
+    do
+        local msg_id = make_msg_id()
+        local initial_token = 0
+        local msg = string.format("SET /locks/1 %016x 42 %s", initial_token, msg_id)
+        print("[test] sending SET lock=1 holder=42 to Hi")
+        local reply = send_recv(sock, host, hi_client_port, msg)
+        if not reply then
+            io.stderr:write("FAIL: test b: no reply\n")
+            failures = failures + 1
+        elseif reply.type ~= "REPLY" or reply.status ~= "OK" or reply.holder ~= 42 then
+            io.stderr:write(string.format("FAIL: test b: expected OK holder=42, got status=%s holder=%s\n",
+                tostring(reply.status), tostring(reply.holder)))
+            failures = failures + 1
+        else
+            set_token = reply.token
+            print(string.format("[test] test b PASS: SET lock=1 holder=42 via Hi -> OK token=%016x", set_token))
+        end
+    end
+
+    -- Test c: GET lock 1 from Lo -> OK holder=42, token matches test b
+    do
+        local msg_id = make_msg_id()
+        local msg = string.format("GET /locks/1 %s", msg_id)
+        print("[test] sending GET lock=1 to Lo")
+        local reply = send_recv(sock, host, lo_client_port, msg)
+        if not reply then
+            io.stderr:write("FAIL: test c: no reply\n")
+            failures = failures + 1
+        elseif reply.type ~= "REPLY" or reply.status ~= "OK" or reply.holder ~= 42 then
+            io.stderr:write(string.format("FAIL: test c: expected OK holder=42, got status=%s holder=%s\n",
+                tostring(reply.status), tostring(reply.holder)))
+            failures = failures + 1
+        elseif set_token and reply.token ~= set_token then
+            io.stderr:write(string.format("FAIL: test c: token mismatch: expected %016x got %016x\n",
+                set_token, reply.token))
+            failures = failures + 1
+        else
+            print("[test] test c PASS: GET lock=1 from Lo -> OK holder=42, token matches")
+        end
+    end
+
+    -- Test d: SET lock 1 with stale token via Hi -> CONFLICT holder=42
+    do
+        local msg_id = make_msg_id()
+        local stale_token = 0
+        local msg = string.format("SET /locks/1 %016x 99 %s", stale_token, msg_id)
+        print("[test] sending SET lock=1 with stale token to Hi")
+        local reply = send_recv(sock, host, hi_client_port, msg)
+        if not reply then
+            io.stderr:write("FAIL: test d: no reply\n")
+            failures = failures + 1
+        elseif reply.type ~= "REPLY" or reply.status ~= "CONFLICT" or reply.holder ~= 42 then
+            io.stderr:write(string.format("FAIL: test d: expected CONFLICT holder=42, got status=%s holder=%s\n",
+                tostring(reply.status), tostring(reply.holder)))
+            failures = failures + 1
+        else
+            print("[test] test d PASS: SET lock=1 stale token via Hi -> CONFLICT holder=42")
+        end
+    end
+
+    -- Test e: GET lock 1 from Hi -> still holder=42 (unchanged)
+    do
+        local msg_id = make_msg_id()
+        local msg = string.format("GET /locks/1 %s", msg_id)
+        print("[test] sending GET lock=1 to Hi")
+        local reply = send_recv(sock, host, hi_client_port, msg)
+        if not reply then
+            io.stderr:write("FAIL: test e: no reply\n")
+            failures = failures + 1
+        elseif reply.type ~= "REPLY" or reply.status ~= "OK" or reply.holder ~= 42 then
+            io.stderr:write(string.format("FAIL: test e: expected OK holder=42, got status=%s holder=%s\n",
+                tostring(reply.status), tostring(reply.holder)))
+            failures = failures + 1
+        else
+            print("[test] test e PASS: GET lock=1 from Hi -> still holder=42")
+        end
+    end
+
+    udp.close(sock)
+
+    if failures > 0 then
+        io.stderr:write("FAIL: " .. failures .. " test(s) failed\n")
+        os.exit(1)
+    end
+
+    print("PASS: all item05 test client checks passed")
+    os.exit(0)
+end)

--- a/test/item06_e2e_test.sh
+++ b/test/item06_e2e_test.sh
@@ -2,5 +2,8 @@
 # Test for Item 06: E2E Harness
 set -euo pipefail
 
-echo "NOT YET IMPLEMENTED"
-exit 1
+cd "$(dirname "$0")/.."
+
+timeout 60 make -C examples/advisory_lock_cas test-e2e
+echo "PASS: item06 E2E harness test passed"
+exit 0

--- a/test/item06_e2e_test.sh
+++ b/test/item06_e2e_test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Test for Item 06: E2E Harness
+set -euo pipefail
+
+echo "NOT YET IMPLEMENTED"
+exit 1

--- a/test/item07_concurrent_test.sh
+++ b/test/item07_concurrent_test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Test for Item 07: Concurrent SET Verification
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+LUNET_BIN="./build/macosx/arm64/release/lunet-run"
+CONFIG_GEN="examples/advisory_lock_cas/config_gen.lua"
+NODE="examples/advisory_lock_cas/node.lua"
+TEST_CLIENT="test/item07_test_client.lua"
+CONFIG=".tmp/advisory_lock_config.lua"
+READY_HI=".tmp/advisory_lock_node_hi_ready"
+READY_LO=".tmp/advisory_lock_node_lo_ready"
+HI_LOG=".tmp/test_item07_hi.log"
+LO_LOG=".tmp/test_item07_lo.log"
+CLIENT_LOG=".tmp/test_item07_client.log"
+
+cleanup() {
+    if [[ -n "${HI_PID:-}" ]] && kill -0 "$HI_PID" 2>/dev/null; then
+        kill -TERM "$HI_PID" 2>/dev/null || true
+        wait "$HI_PID" 2>/dev/null || true
+    fi
+    if [[ -n "${LO_PID:-}" ]] && kill -0 "$LO_PID" 2>/dev/null; then
+        kill -TERM "$LO_PID" 2>/dev/null || true
+        wait "$LO_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+rm -f "$READY_HI" "$READY_LO" "$CONFIG" "$HI_LOG" "$LO_LOG" "$CLIENT_LOG"
+mkdir -p .tmp
+
+echo "--- Step 1: Generate config ---"
+timeout 10 "$LUNET_BIN" "$CONFIG_GEN" --output "$CONFIG"
+if [[ ! -f "$CONFIG" ]]; then
+    echo "FAIL: config file not created"
+    exit 1
+fi
+
+echo "--- Step 2: Start HI node ---"
+"$LUNET_BIN" "$NODE" --hi "$CONFIG" >"$HI_LOG" 2>&1 &
+HI_PID=$!
+
+echo "--- Step 3: Poll for HI readiness (5s timeout) ---"
+for i in $(seq 1 50); do
+    if [[ -f "$READY_HI" ]]; then break; fi
+    if ! kill -0 "$HI_PID" 2>/dev/null; then
+        echo "FAIL: HI node exited prematurely"
+        cat "$HI_LOG"
+        exit 1
+    fi
+    sleep 0.1
+done
+if [[ ! -f "$READY_HI" ]]; then
+    echo "FAIL: HI readiness file not found after 5s"
+    cat "$HI_LOG"
+    exit 1
+fi
+
+echo "--- Step 4: Start LO node ---"
+"$LUNET_BIN" "$NODE" --lo "$CONFIG" >"$LO_LOG" 2>&1 &
+LO_PID=$!
+
+echo "--- Step 5: Poll for LO readiness (5s timeout) ---"
+for i in $(seq 1 50); do
+    if [[ -f "$READY_LO" ]]; then break; fi
+    if ! kill -0 "$LO_PID" 2>/dev/null; then
+        echo "FAIL: LO node exited prematurely"
+        cat "$LO_LOG"
+        exit 1
+    fi
+    sleep 0.1
+done
+if [[ ! -f "$READY_LO" ]]; then
+    echo "FAIL: LO readiness file not found after 5s"
+    cat "$LO_LOG"
+    exit 1
+fi
+
+echo "--- Step 6: Run test client ---"
+set +e
+timeout 30 "$LUNET_BIN" "$TEST_CLIENT" >"$CLIENT_LOG" 2>&1
+CLIENT_EXIT=$?
+set -e
+
+cat "$CLIENT_LOG"
+
+if [[ "$CLIENT_EXIT" -ne 0 ]]; then
+    echo "FAIL: test client exited with code $CLIENT_EXIT"
+    echo "--- HI node log ---"
+    cat "$HI_LOG"
+    echo "--- LO node log ---"
+    cat "$LO_LOG"
+    exit 1
+fi
+
+echo "--- Step 7: Kill nodes ---"
+kill -TERM "$HI_PID" 2>/dev/null || true
+kill -TERM "$LO_PID" 2>/dev/null || true
+wait "$HI_PID" 2>/dev/null || true
+wait "$LO_PID" 2>/dev/null || true
+HI_PID=""
+LO_PID=""
+
+echo "PASS: item07 concurrent SET verification passed"
+exit 0

--- a/test/item07_test_client.lua
+++ b/test/item07_test_client.lua
@@ -165,13 +165,11 @@ lunet.spawn(function()
             results.b and tostring(results.b.status) or "nil"))
 
     -- Test h: loser's CONFLICT shows winner's holder
-    local winner_holder, loser_holder
+    local winner_holder
     if a_ok then
         winner_holder = 100
-        loser_holder = 200
     else
         winner_holder = 200
-        loser_holder = 100
     end
 
     local loser_reply = a_ok and results.b or results.a

--- a/test/item07_test_client.lua
+++ b/test/item07_test_client.lua
@@ -1,0 +1,259 @@
+#!/usr/bin/env lua
+-- Test Client for Item 07: Concurrent SET Verification
+
+local lunet = require("lunet")
+local udp = require("lunet.udp")
+
+local script_dir = debug.getinfo(1, "S").source:match("^@(.+)/[^/]+$") or "."
+local config_path = ".tmp/advisory_lock_config.lua"
+
+local config = dofile(config_path)
+if type(config) ~= "table" then
+    io.stderr:write("FAIL: cannot load config\n")
+    os.exit(1)
+end
+
+local codec = dofile(script_dir .. "/../examples/advisory_lock_cas/codec.lua")
+
+local hi_client_port = config.hi.client_port
+local lo_client_port = config.lo.client_port
+local host = "127.0.0.1"
+
+local checks_passed = 0
+local checks_failed = 0
+
+local function check(name, cond, msg)
+    if cond then
+        checks_passed = checks_passed + 1
+        print("[test] " .. name .. " PASS")
+    else
+        checks_failed = checks_failed + 1
+        io.stderr:write("[test] " .. name .. " FAIL: " .. msg .. "\n")
+    end
+end
+
+local function send_recv(sock, target_host, target_port, msg)
+    local ok, err = udp.send(sock, target_host, target_port, msg)
+    if not ok then
+        io.stderr:write("FAIL: send error: " .. tostring(err) .. "\n")
+        return nil
+    end
+    local data, _, _ = udp.recv(sock)
+    if not data then
+        io.stderr:write("FAIL: recv returned nil\n")
+        return nil
+    end
+    return codec.parse(data)
+end
+
+local function make_msg_id()
+    return string.format("%08x", math.random(0, 0xFFFFFFFF))
+end
+
+lunet.spawn(function()
+    local sock, err = udp.bind(host, 0)
+    if not sock then
+        io.stderr:write("FAIL: cannot bind client socket: " .. tostring(err) .. "\n")
+        os.exit(1)
+    end
+
+    -- Test a: GET lock 1 from Hi -> OK holder=0
+    do
+        local msg_id = make_msg_id()
+        local msg = string.format("GET /locks/1 %s", msg_id)
+        local reply = send_recv(sock, host, hi_client_port, msg)
+        check("a: GET lock=1 from Hi",
+            reply and reply.type == "REPLY" and reply.status == "OK" and reply.holder == 0,
+            string.format("expected OK holder=0, got status=%s holder=%s",
+                reply and tostring(reply.status) or "nil",
+                reply and tostring(reply.holder) or "nil"))
+    end
+
+    -- Test b: SET lock 1 to holder=42 via Hi -> OK
+    local set_b_token
+    do
+        local msg_id = make_msg_id()
+        local msg = string.format("SET /locks/1 %016x 42 %s", 0, msg_id)
+        local reply = send_recv(sock, host, hi_client_port, msg)
+        set_b_token = reply and reply.token
+        check("b: SET lock=1 holder=42 via Hi",
+            reply and reply.type == "REPLY" and reply.status == "OK" and reply.holder == 42,
+            string.format("expected OK holder=42, got status=%s holder=%s",
+                reply and tostring(reply.status) or "nil",
+                reply and tostring(reply.holder) or "nil"))
+    end
+
+    -- Test c: GET lock 1 from Lo -> OK holder=42, token matches
+    do
+        local msg_id = make_msg_id()
+        local msg = string.format("GET /locks/1 %s", msg_id)
+        local reply = send_recv(sock, host, lo_client_port, msg)
+        local token_ok = set_b_token and reply and reply.token == set_b_token
+        check("c: GET lock=1 from Lo",
+            reply and reply.type == "REPLY" and reply.status == "OK" and reply.holder == 42 and token_ok,
+            string.format("expected OK holder=42 token match, got status=%s holder=%s token=%s",
+                reply and tostring(reply.status) or "nil",
+                reply and tostring(reply.holder) or "nil",
+                reply and string.format("%016x", reply.token) or "nil"))
+    end
+
+    -- Test d: SET lock 1 with stale token via Hi -> CONFLICT holder=42
+    do
+        local msg_id = make_msg_id()
+        local msg = string.format("SET /locks/1 %016x 99 %s", 0, msg_id)
+        local reply = send_recv(sock, host, hi_client_port, msg)
+        check("d: SET lock=1 stale token via Hi",
+            reply and reply.type == "REPLY" and reply.status == "CONFLICT" and reply.holder == 42,
+            string.format("expected CONFLICT holder=42, got status=%s holder=%s",
+                reply and tostring(reply.status) or "nil",
+                reply and tostring(reply.holder) or "nil"))
+    end
+
+    -- Concurrent test: lock 2, both nodes, two competing SETs
+    local results = {}
+    local done_count = 0
+
+    local sock_a, sa_err = udp.bind(host, 0)
+    if not sock_a then
+        io.stderr:write("FAIL: cannot bind sock_a: " .. tostring(sa_err) .. "\n")
+        os.exit(1)
+    end
+
+    local sock_b, sb_err = udp.bind(host, 0)
+    if not sock_b then
+        io.stderr:write("FAIL: cannot bind sock_b: " .. tostring(sb_err) .. "\n")
+        os.exit(1)
+    end
+
+    local unheld_token = 2 * 0x100000000
+
+    lunet.spawn(function()
+        local msg_id = make_msg_id()
+        local msg = string.format("SET /locks/2 %016x 100 %s", unheld_token, msg_id)
+        local reply = send_recv(sock_a, host, hi_client_port, msg)
+        results.a = reply
+        done_count = done_count + 1
+    end)
+
+    lunet.sleep(50)
+
+    lunet.spawn(function()
+        local msg_id = make_msg_id()
+        local msg = string.format("SET /locks/2 %016x 200 %s", unheld_token, msg_id)
+        local reply = send_recv(sock_b, host, lo_client_port, msg)
+        results.b = reply
+        done_count = done_count + 1
+    end)
+
+    local wait_limit = 100
+    local waited = 0
+    while done_count < 2 and waited < wait_limit do
+        lunet.sleep(100)
+        waited = waited + 1
+    end
+
+    -- Test g: exactly one OK, exactly one CONFLICT
+    local a_ok = results.a and results.a.status == "OK"
+    local b_ok = results.b and results.b.status == "OK"
+    local a_conflict = results.a and results.a.status == "CONFLICT"
+    local b_conflict = results.b and results.b.status == "CONFLICT"
+
+    check("g: exactly one OK and one CONFLICT",
+        (a_ok and b_conflict) or (b_ok and a_conflict),
+        string.format("a.status=%s b.status=%s",
+            results.a and tostring(results.a.status) or "nil",
+            results.b and tostring(results.b.status) or "nil"))
+
+    -- Test h: loser's CONFLICT shows winner's holder
+    local winner_holder, loser_holder
+    if a_ok then
+        winner_holder = 100
+        loser_holder = 200
+    else
+        winner_holder = 200
+        loser_holder = 100
+    end
+
+    local loser_reply = a_ok and results.b or results.a
+    check("h: loser CONFLICT shows winner's holder",
+        loser_reply and loser_reply.status == "CONFLICT" and loser_reply.holder == winner_holder,
+        string.format("expected CONFLICT holder=%d, got status=%s holder=%s",
+            winner_holder,
+            loser_reply and tostring(loser_reply.status) or "nil",
+            loser_reply and tostring(loser_reply.holder) or "nil"))
+
+    local winner_reply = a_ok and results.a or results.b
+    local winner_token = winner_reply and winner_reply.token
+
+    -- Test i: GET lock 2 from Hi -> holder matches winner
+    do
+        local msg_id = make_msg_id()
+        local msg = string.format("GET /locks/2 %s", msg_id)
+        local reply = send_recv(sock, host, hi_client_port, msg)
+        check("i: GET lock=2 from Hi matches winner",
+            reply and reply.type == "REPLY" and reply.status == "OK" and reply.holder == winner_holder,
+            string.format("expected OK holder=%d, got status=%s holder=%s",
+                winner_holder,
+                reply and tostring(reply.status) or "nil",
+                reply and tostring(reply.holder) or "nil"))
+    end
+
+    -- Test j: GET lock 2 from Lo -> holder matches winner
+    do
+        local msg_id = make_msg_id()
+        local msg = string.format("GET /locks/2 %s", msg_id)
+        local reply = send_recv(sock, host, lo_client_port, msg)
+        check("j: GET lock=2 from Lo matches winner",
+            reply and reply.type == "REPLY" and reply.status == "OK" and reply.holder == winner_holder,
+            string.format("expected OK holder=%d, got status=%s holder=%s",
+                winner_holder,
+                reply and tostring(reply.status) or "nil",
+                reply and tostring(reply.holder) or "nil"))
+    end
+
+    -- Test k: SET lock 2 with correct token to holder=77 -> OK
+    do
+        local msg_id = make_msg_id()
+        local msg = string.format("SET /locks/2 %016x 77 %s", winner_token, msg_id)
+        local reply = send_recv(sock, host, hi_client_port, msg)
+        check("k: SET lock=2 holder=77 via Hi",
+            reply and reply.type == "REPLY" and reply.status == "OK" and reply.holder == 77,
+            string.format("expected OK holder=77, got status=%s holder=%s",
+                reply and tostring(reply.status) or "nil",
+                reply and tostring(reply.holder) or "nil"))
+    end
+
+    -- Test l: GET lock 2 from both nodes -> holder=77
+    do
+        local msg_id = make_msg_id()
+        local msg = string.format("GET /locks/2 %s", msg_id)
+        local reply_hi = send_recv(sock, host, hi_client_port, msg)
+        check("l1: GET lock=2 from Hi -> holder=77",
+            reply_hi and reply_hi.type == "REPLY" and reply_hi.status == "OK" and reply_hi.holder == 77,
+            string.format("expected OK holder=77, got status=%s holder=%s",
+                reply_hi and tostring(reply_hi.status) or "nil",
+                reply_hi and tostring(reply_hi.holder) or "nil"))
+    end
+    do
+        local msg_id = make_msg_id()
+        local msg = string.format("GET /locks/2 %s", msg_id)
+        local reply_lo = send_recv(sock, host, lo_client_port, msg)
+        check("l2: GET lock=2 from Lo -> holder=77",
+            reply_lo and reply_lo.type == "REPLY" and reply_lo.status == "OK" and reply_lo.holder == 77,
+            string.format("expected OK holder=77, got status=%s holder=%s",
+                reply_lo and tostring(reply_lo.status) or "nil",
+                reply_lo and tostring(reply_lo.holder) or "nil"))
+    end
+
+    udp.close(sock_a)
+    udp.close(sock_b)
+    udp.close(sock)
+
+    if checks_failed > 0 then
+        io.stderr:write("FAIL: " .. checks_failed .. " check(s) failed\n")
+        os.exit(1)
+    end
+
+    print("=== concurrent advisory lock CAS: all " .. checks_passed .. " checks passed ===")
+    os.exit(0)
+end)

--- a/test/udp_relay_roundtrip.lua
+++ b/test/udp_relay_roundtrip.lua
@@ -85,7 +85,7 @@ lunet.spawn(function()
       print("RELAY: forwarded to peer")
     end
 
-    local reply, rhost, rport = udp.recv(peer_sock)
+    local reply = udp.recv(peer_sock)
     check(reply == data,
       "relay received echo: got '" .. tostring(reply) .. "' expected '" .. tostring(data) .. "'")
 
@@ -128,7 +128,7 @@ lunet.spawn(function()
     assert(ok, serr)
     print("CLIENT: sent #" .. (i + 1) .. " '" .. pl .. "'")
 
-    reply, rhost = udp.recv(h)
+    reply = udp.recv(h)
     check(reply == pl,
       "client roundtrip #" .. (i + 1) .. ": got '" .. tostring(reply) .. "' expected '" .. pl .. "'")
   end

--- a/test/udp_relay_roundtrip.lua
+++ b/test/udp_relay_roundtrip.lua
@@ -1,0 +1,143 @@
+--[[
+  UDP Relay Roundtrip Test
+
+  Proves that a single coroutine can:
+    1. recv from a client-facing UDP socket
+    2. send to a peer
+    3. recv from the peer
+    4. send the reply back to the original client
+
+  This is the fundamental pattern needed for the advisory-lock CAS demo.
+
+  Architecture (all in one process, loopback):
+    Peer (coroutine 1): echo server on fixed port
+    Relay (coroutine 2): client-facing socket + ephemeral peer socket
+    Client (coroutine 3): ephemeral socket, sends "hello", expects "hello" back
+
+  Usage:
+    ./build/lunet test/udp_relay_roundtrip.lua
+
+  Expected exit code: 0 (all assertions pass)
+  Expected exit code: 1 (any assertion fails, or timeout)
+]]
+
+local lunet = require("lunet")
+local udp = require("lunet.udp")
+
+local PEER_HOST = "127.0.0.1"
+local PEER_PORT = 21001
+local RELAY_CLIENT_PORT = 21002
+
+local failures = 0
+local checks = 0
+
+local function check(cond, msg)
+  checks = checks + 1
+  if not cond then
+    failures = failures + 1
+    io.stderr:write("FAIL: " .. msg .. "\n")
+  else
+    print("   OK: " .. msg)
+  end
+end
+
+-- ── Coroutine 1: Peer (echo server) ──────────────────────────────────────
+lunet.spawn(function()
+  local h, err = udp.bind(PEER_HOST, PEER_PORT)
+  assert(h, err)
+  print("PEER: bound on " .. PEER_HOST .. ":" .. PEER_PORT)
+
+  for _ = 1, 3 do
+    local data, host, port = udp.recv(h)
+    print("PEER: recv '" .. data .. "' from " .. host .. ":" .. port)
+    local ok, serr = udp.send(h, host, port, data)
+    if not ok then
+      io.stderr:write("PEER: send failed: " .. tostring(serr) .. "\n")
+    else
+      print("PEER: echoed back")
+    end
+  end
+
+  udp.close(h)
+  print("PEER: done")
+end)
+
+-- ── Coroutine 2: Relay Node (client-facing + peer-facing) ─────────────────
+lunet.spawn(function()
+  lunet.sleep(0.1) -- let peer bind first
+
+  local client_sock, cerr = udp.bind(PEER_HOST, RELAY_CLIENT_PORT)
+  assert(client_sock, cerr)
+  print("RELAY: client socket on " .. PEER_HOST .. ":" .. RELAY_CLIENT_PORT)
+
+  local peer_sock, perr = udp.bind(PEER_HOST, 0)
+  assert(peer_sock, perr)
+  print("RELAY: peer socket bound (ephemeral)")
+
+  for _ = 1, 3 do
+    local data, host, port = udp.recv(client_sock)
+    print("RELAY: recv '" .. data .. "' from " .. host .. ":" .. port)
+
+    local ok, serr = udp.send(peer_sock, PEER_HOST, PEER_PORT, data)
+    if not ok then
+      io.stderr:write("RELAY: send to peer failed: " .. tostring(serr) .. "\n")
+    else
+      print("RELAY: forwarded to peer")
+    end
+
+    local reply, rhost, rport = udp.recv(peer_sock)
+    check(reply == data,
+      "relay received echo: got '" .. tostring(reply) .. "' expected '" .. tostring(data) .. "'")
+
+    local ok2, serr2 = udp.send(client_sock, host, port, reply)
+    if not ok2 then
+      io.stderr:write("RELAY: send to client failed: " .. tostring(serr2) .. "\n")
+    else
+      print("RELAY: replied to client " .. host .. ":" .. port)
+    end
+  end
+
+  udp.close(client_sock)
+  udp.close(peer_sock)
+  print("RELAY: done")
+end)
+
+-- ── Coroutine 3: Client ───────────────────────────────────────────────────
+lunet.spawn(function()
+  lunet.sleep(0.2) -- let peer + relay bind first
+
+  local h, err = udp.bind(PEER_HOST, 0)
+  assert(h, err)
+  print("CLIENT: bound (ephemeral)")
+
+  local payload = "hello"
+  local ok, serr = udp.send(h, PEER_HOST, RELAY_CLIENT_PORT, payload)
+  assert(ok, serr)
+  print("CLIENT: sent '" .. payload .. "'")
+
+  local reply, rhost, rport = udp.recv(h)
+  check(reply == payload,
+    "client roundtrip: got '" .. tostring(reply) .. "' expected '" .. payload .. "'")
+  check(rhost == PEER_HOST,
+    "client reply from correct host: " .. tostring(rhost))
+  print("CLIENT: got reply '" .. tostring(reply) .. "' from " .. tostring(rhost) .. ":" .. tostring(rport))
+
+  -- Send two more to verify sequential relay works
+  for i, pl in ipairs({"world", "lunet"}) do
+    ok, serr = udp.send(h, PEER_HOST, RELAY_CLIENT_PORT, pl)
+    assert(ok, serr)
+    print("CLIENT: sent #" .. (i + 1) .. " '" .. pl .. "'")
+
+    reply, rhost = udp.recv(h)
+    check(reply == pl,
+      "client roundtrip #" .. (i + 1) .. ": got '" .. tostring(reply) .. "' expected '" .. pl .. "'")
+  end
+
+  udp.close(h)
+  print("CLIENT: done")
+
+  -- Report and exit
+  print(failures > 0 and ("\n=== " .. failures .. "/" .. checks .. " FAILURES ===")
+    or ("\n=== all " .. checks .. " checks passed ==="))
+  os.exit(failures > 0 and 1 or 0)
+end)

--- a/types/lunet/udp.lua
+++ b/types/lunet/udp.lua
@@ -33,4 +33,11 @@ function udp.recv(handle) end
 ---@return string|nil error
 function udp.close(handle) end
 
+---Get the local address and port of a bound UDP socket.
+---@param handle lightuserdata
+---@return string|nil host The local host address
+---@return integer|nil port The local port number
+---@return string|nil error Error message if failed
+function udp.getsockname(handle) end
+
 return udp


### PR DESCRIPTION
Closes #128

## What

Two-node UDP advisory-lock CAS demo. Demonstrates client → node → peer → node → client relay with compare-and-swap semantics.

## Commits

- `69ee83e` Item 01: config generator (port discovery, Lua output)
- `8f0dd8a` Item 02: lock table + CAS (pure functions)
- `d001fc8` Item 03: message codec (parse + format)
- `282030b` Item 04: node skeleton (args, bind, readiness)
- `959351f` Item 05: node main loop (codec + lock + relay)
- `312e014` Item 06: E2E harness (Makefile, run_demo.sh)
- `21cbf32` Item 07: concurrent SET verification

## Core additions

- `udp.getsockname()` — discover ephemeral port after bind
- `arg` table support in `lunet-run` for CLI argument parsing

## Verification

```bash
make -C examples/advisory_lock_cas test-e2e
make -C examples/advisory_lock_cas test-concurrent
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lua-lunet/codesmith/lunet/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->