### PR TITLE
docs: add RELEASE-LAYOUT.md to binary archives (closes #133)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,6 +298,8 @@ jobs:
         # DB transaction wrappers (#119): one per driver, deliberately not shared.
         cp ext/sqlite3/sqlite3_tx.lua ext/postgres/postgres_tx.lua \
            ext/mysql/mysql_tx.lua "$DIST_DIR/lunet/"
+        # Release layout documentation (#133)
+        cp docs/RELEASE-LAYOUT.md docs/RELEASE-LAYOUT-CN.md "$DIST_DIR/"
         tar -C "$DIST_DIR" -czf "lunet-linux-${{ matrix.arch }}.tar.gz" .
 
     - name: Package release archive (macOS)
@@ -321,6 +323,8 @@ jobs:
         # DB transaction wrappers (#119): one per driver, deliberately not shared.
         cp ext/sqlite3/sqlite3_tx.lua ext/postgres/postgres_tx.lua \
            ext/mysql/mysql_tx.lua "$DIST_DIR/lunet/"
+        # Release layout documentation (#133)
+        cp docs/RELEASE-LAYOUT.md docs/RELEASE-LAYOUT-CN.md "$DIST_DIR/"
         tar -C "$DIST_DIR" -czf lunet-macos.tar.gz .
 
     - name: Package release SDK (Linux)
@@ -369,6 +373,8 @@ jobs:
         }
         # DB transaction wrappers (#119): one per driver, deliberately not shared.
         Copy-Item ext\sqlite3\sqlite3_tx.lua, ext\postgres\postgres_tx.lua, ext\mysql\mysql_tx.lua (Join-Path $dist "lunet")
+        # Release layout documentation (#133)
+        Copy-Item docs\RELEASE-LAYOUT.md, docs\RELEASE-LAYOUT-CN.md $dist
         Compress-Archive -Path (Join-Path $dist "*") -DestinationPath lunet-windows-amd64.zip -Force
 
     - name: Package release SDK (Windows)

--- a/docs/RELEASE-LAYOUT-CN.md
+++ b/docs/RELEASE-LAYOUT-CN.md
@@ -1,0 +1,235 @@
+# 二进制发布包布局
+
+每个发布版本都会与 SDK 一同发布按平台区分的二进制压缩包：
+
+- `lunet-linux-amd64.tar.gz`
+- `lunet-linux-arm64.tar.gz`
+- `lunet-macos.tar.gz`
+- `lunet-windows-amd64.zip`
+
+这是一个自包含的部署包：解压到任意目录后直接运行 `lunet-run` 即可，无需其他
+安装步骤。
+
+## 压缩包布局
+
+```text
+lunet-run                           # 独立可执行文件（Windows 上为 lunet-run.exe）
+lunet.so                            # 核心动态库，用于 require("lunet")
+                                    #   （Windows 上为 lunet.dll）
+lunet/                              # 扩展模块
+  sqlite3.so / postgres.so          # 数据库驱动动态库
+  mysql.so                          #   （Windows 上为 .dll）
+  sqlite3_tx.lua / postgres_tx.lua  # 数据库事务封装
+  mysql_tx.lua
+  liblnt_shared.so                  # lnt_shared 共享字典（Linux）
+  liblnt_shared.dylib               #   （macOS，Windows 不提供）
+  lnt_shared.lua                    # lnt_shared Lua FFI 加载器
+  liblunet_jsonic.so                # jsonic 流式 JSON 解码器（Linux）
+  liblunet_jsonic.dylib             #   （macOS，Windows 不提供）
+  jsonic.lua                        # jsonic Lua FFI 加载器 + 编码器
+  dkjson-encode-v2.10.lua           # 有序 JSON 编码器（jsonic 依赖）
+```
+
+## 扩展加载机制
+
+`lunet-run` 启动时会自动将 `<可执行文件目录>/lunet/?.lua` 加入 `package.path`，
+并将 `<可执行文件目录>/lunet/?.so` 加入 `package.cpath`（使用正确的平台后缀）。
+这意味着只要保持压缩包的目录结构不变，以下代码可以从任意工作目录正常运行：
+
+```lua
+local cache = require("lunet.lnt_shared")
+local json  = require("lunet.jsonic")
+```
+
+每个 Lua 加载器（`lnt_shared.lua`、`jsonic.lua`）会相对于自身所在目录解析
+编译后的库文件，因此无需手动配置。
+
+如果将 `.so`/`.dylib` 文件移动到其他位置，请设置对应加载器检查的环境变量：
+
+| 扩展       | 环境变量                     |
+|------------|------------------------------|
+| lnt_shared | `LUNET_LNT_SHARED_LIB`       |
+| jsonic     | `LUNET_JSONIC_LIB`           |
+
+## 独立使用扩展（不依赖 lunet-run）
+
+两个 Rust 扩展都导出了稳定的 C ABI，任何 LuaJIT 程序都可以通过 `ffi.load()`
+直接加载。以下章节记录了完整的 FFI API 接口——cdef 声明、错误码和值类型常量。
+
+无需头文件：以下声明使用 LuaJIT FFI cdef 语法编写，可以直接粘贴到
+`ffi.cdef[[...]]` 块中使用。
+
+---
+
+## lnt_shared — 共享字典
+
+仅限 POSIX 平台（Linux / macOS）。基于 `mmap(MAP_SHARED|MAP_ANONYMOUS)` 的
+内存键值存储，支持 TTL 过期机制。
+
+### FFI 声明
+
+```lua
+ffi.cdef[[
+  /* 不透明字典句柄 */
+  typedef void* ngx_shared_handle_t;
+
+  /* 生命周期 */
+  ngx_shared_handle_t ngx_shared_open(const char* name, uint64_t size_bytes);
+  void                ngx_shared_close(ngx_shared_handle_t h);
+
+  /* CRUD 操作 */
+  int  ngx_shared_get(ngx_shared_handle_t h,
+                      const uint8_t* key, size_t klen,
+                      uint8_t** out_val, size_t* out_len, int* out_type);
+  void ngx_shared_free_bytes(uint8_t* p, size_t len);
+
+  int  ngx_shared_set(ngx_shared_handle_t h,
+                      const uint8_t* key, size_t klen,
+                      const uint8_t* val, size_t vlen,
+                      int val_type, double ttl_secs);
+  int  ngx_shared_add(ngx_shared_handle_t h,
+                      const uint8_t* key, size_t klen,
+                      const uint8_t* val, size_t vlen,
+                      int val_type, double ttl_secs);
+  int  ngx_shared_replace(ngx_shared_handle_t h,
+                          const uint8_t* key, size_t klen,
+                          const uint8_t* val, size_t vlen,
+                          int val_type, double ttl_secs);
+  int  ngx_shared_delete(ngx_shared_handle_t h,
+                         const uint8_t* key, size_t klen);
+
+  /* 数值递增 */
+  int  ngx_shared_incr(ngx_shared_handle_t h,
+                       const uint8_t* key, size_t klen,
+                       double delta, double init, int has_init,
+                       double ttl_secs, double* result);
+
+  /* TTL 管理 */
+  int  ngx_shared_expire(ngx_shared_handle_t h,
+                         const uint8_t* key, size_t klen,
+                         double ttl_secs);
+  int  ngx_shared_ttl(ngx_shared_handle_t h,
+                      const uint8_t* key, size_t klen,
+                      double* out_ttl);
+
+  /* 批量操作 */
+  void ngx_shared_flush_all(ngx_shared_handle_t h);
+  int  ngx_shared_flush_expired(ngx_shared_handle_t h, int max);
+
+  /* 统计 */
+  uint64_t ngx_shared_capacity(ngx_shared_handle_t h);
+  uint64_t ngx_shared_free_space(ngx_shared_handle_t h);
+]]
+```
+
+### 错误码
+
+| 代码  | 常量                     | 含义               |
+|-------|--------------------------|---------------------|
+| `0`   | `NGX_SHARED_OK`          | 成功               |
+| `-1`  | `NGX_SHARED_NOT_FOUND`   | 键不存在           |
+| `-2`  | `NGX_SHARED_ERR_EXISTS`  | 键已存在           |
+| `-3`  | `NGX_SHARED_ERR_NOMEM`   | 内存不足           |
+| `-4`  | `NGX_SHARED_ERR_TYPE`    | 值类型不匹配       |
+| `-5`  | `NGX_SHARED_ERR_FULL`    | 哈希表已满         |
+| `-6`  | `NGX_SHARED_ERR_INVAL`   | 参数无效           |
+
+### 值类型
+
+| 常量    | 值   | 存储格式                  |
+|---------|------|---------------------------|
+| bytes   | `0`  | 原始字节                  |
+| f64     | `1`  | IEEE 754 双精度，小端序   |
+| bool    | `2`  | 单字节（0 或 1）          |
+
+### 内存所有权
+
+`ngx_shared_get` 会在堆上分配一个缓冲区来存放返回值。调用者**必须**使用
+`ngx_shared_free_bytes(ptr, len)` 释放该缓冲区。`lnt_shared.lua` 中的 Lua
+封装层会自动处理释放；独立 FFI 用户需要自行调用 `free_bytes`。
+
+### 符号命名
+
+FFI 符号使用 `ngx_shared_*` 前缀（而非 `lnt_shared_*`）。这是从 `ngx_shared`
+重命名为 `lnt_shared`（v0.4.3）后保留的旧名，用于保持 ABI 兼容性。这些符号
+是稳定的，不会变更。
+
+### 最小示例（独立 FFI）
+
+```lua
+local ffi = require("ffi")
+ffi.cdef[[ /* 粘贴上方 cdef 块 */ ]]
+local lib = ffi.load("./lunet/liblnt_shared.so")  -- macOS 上为 .dylib
+
+local h = lib.ngx_shared_open("my_dict", 65536)
+assert(h ~= nil)
+
+-- 设置一个字符串值
+local rc = lib.ngx_shared_set(h, "greeting", 8, "hello", 5, 0, 0)
+assert(rc == 0)
+
+-- 读取回来
+local out_val = ffi.new("uint8_t*[1]")
+local out_len = ffi.new("size_t[1]")
+local out_type = ffi.new("int[1]")
+rc = lib.ngx_shared_get(h, "greeting", 8, out_val, out_len, out_type)
+assert(rc == 0)
+print(ffi.string(out_val[0], out_len[0]))  --> "hello"
+lib.ngx_shared_free_bytes(out_val[0], out_len[0])
+
+lib.ngx_shared_close(h)
+```
+
+---
+
+## jsonic — 流式 JSON 编解码器
+
+仅限 POSIX 平台（Linux / macOS）。提供流式 JSON 解码器（搭配 Lua 端编码器）。
+
+### FFI 声明
+
+```lua
+ffi.cdef[[
+  int  lunet_jsonic_decode(const uint8_t* json, size_t len,
+                           uint8_t** out, size_t* out_len);
+  void lunet_jsonic_free_bytes(uint8_t* p, size_t len);
+]]
+```
+
+### 错误码
+
+| 代码  | 常量               | 含义           |
+|-------|--------------------|----------------|
+| `0`   | `JSONIC_OK`        | 成功           |
+| `-1`  | `JSONIC_ERR_PARSE` | 解析错误       |
+| `-2`  | `JSONIC_ERR_INVAL` | 参数无效       |
+
+### 二进制传输格式
+
+`lunet_jsonic_decode` 返回的是二进制编码（非 JSON 文本）。`jsonic.lua` 中的
+Lua 加载器会将其解码为 Lua 表。需要解码后的 Lua 值的独立 FFI 用户应使用
+Lua 封装层，而不是直接调用 FFI——二进制格式属于编解码器内部实现。
+
+### 内存所有权
+
+与 lnt_shared 相同：`lunet_jsonic_decode` 在堆上分配输出缓冲区，调用者必须
+使用 `lunet_jsonic_free_bytes` 释放。
+
+---
+
+## 数据库驱动
+
+`lunet/` 目录下的 `.so`/`.dll` 文件会在首次访问对应 Lua 模块时由 `require()`
+自动加载。事务封装（`*_tx.lua`）是纯 Lua 模块，为原生驱动连接添加了
+`conn:begin()`、`conn:commit()` 和 `conn:rollback()` 方法。
+
+---
+
+## 平台说明
+
+- **Linux (amd64 / arm64)**：包含所有扩展。在 Ubuntu 24.04 上构建，链接系统
+  `glibc` 和 `openssl`。
+- **macOS (arm64)**：包含所有扩展。在 macOS 15+ 上构建，目标为
+  `macosx-version-min=14.0`。
+- **Windows (amd64)**：Rust 扩展（`lnt_shared`、`jsonic`）因底层 crate 仅限
+  POSIX 平台而未包含。数据库驱动和事务封装正常提供。

--- a/docs/RELEASE-LAYOUT.md
+++ b/docs/RELEASE-LAYOUT.md
@@ -1,0 +1,244 @@
+# Binary Release Layout
+
+Each release publishes a platform-specific binary archive alongside the SDK:
+
+- `lunet-linux-amd64.tar.gz`
+- `lunet-linux-arm64.tar.gz`
+- `lunet-macos.tar.gz`
+- `lunet-windows-amd64.zip`
+
+This archive is a self-contained deployment: extract it anywhere and run
+`lunet-run` directly. No other installation steps are needed.
+
+## Archive layout
+
+```text
+lunet-run                           # standalone executable (lunet-run.exe on Windows)
+lunet.so                            # core shared library for require("lunet")
+                                    #   (lunet.dll on Windows)
+lunet/                              # extension modules
+  sqlite3.so / postgres.so          # DB driver shared libraries
+  mysql.so                          #   (.dll on Windows)
+  sqlite3_tx.lua / postgres_tx.lua  # DB transaction wrappers
+  mysql_tx.lua
+  liblnt_shared.so                  # lnt_shared shared dictionary (Linux)
+  liblnt_shared.dylib               #   (macOS — not shipped on Windows)
+  lnt_shared.lua                    # lnt_shared Lua FFI loader
+  liblunet_jsonic.so                # jsonic streaming JSON decoder (Linux)
+  liblunet_jsonic.dylib             #   (macOS — not shipped on Windows)
+  jsonic.lua                        # jsonic Lua FFI loader + encoder
+  dkjson-encode-v2.10.lua           # ordered-JSON encoder (used by jsonic)
+```
+
+## How extensions are loaded
+
+`lunet-run` automatically adds `<executable_dir>/lunet/?.lua` to `package.path`
+and `<executable_dir>/lunet/?.so` to `package.cpath` at startup (with correct
+platform suffixes). This means the following work from any working directory
+as long as the archive directory tree is preserved:
+
+```lua
+local cache = require("lunet.lnt_shared")
+local json  = require("lunet.jsonic")
+```
+
+Each Lua loader (`lnt_shared.lua`, `jsonic.lua`) resolves its compiled library
+relative to its own directory, so no manual configuration is required.
+
+If you move the `.so`/`.dylib` files elsewhere, set the environment variable
+that the corresponding loader checks:
+
+| Extension  | Environment variable         |
+|------------|------------------------------|
+| lnt_shared | `LUNET_LNT_SHARED_LIB`       |
+| jsonic     | `LUNET_JSONIC_LIB`           |
+
+## Using extensions standalone (without lunet-run)
+
+Both Rust extensions export a stable C ABI and can be loaded directly by any
+LuaJIT program via `ffi.load()`. The sections below document the complete FFI
+API surface — cdef declarations, error codes, and value type constants.
+
+No header files are needed: the declarations below are written in LuaJIT FFI
+cdef syntax and can be pasted directly into a `ffi.cdef[[...]]` block.
+
+---
+
+## lnt_shared — shared dictionary
+
+POSIX-only (Linux / macOS). Provides an in-memory key-value store backed by
+`mmap(MAP_SHARED|MAP_ANONYMOUS)` with TTL-based expiry.
+
+### FFI declarations
+
+```lua
+ffi.cdef[[
+  /* Opaque dictionary handle */
+  typedef void* ngx_shared_handle_t;
+
+  /* Lifecycle */
+  ngx_shared_handle_t ngx_shared_open(const char* name, uint64_t size_bytes);
+  void                ngx_shared_close(ngx_shared_handle_t h);
+
+  /* CRUD */
+  int  ngx_shared_get(ngx_shared_handle_t h,
+                      const uint8_t* key, size_t klen,
+                      uint8_t** out_val, size_t* out_len, int* out_type);
+  void ngx_shared_free_bytes(uint8_t* p, size_t len);
+
+  int  ngx_shared_set(ngx_shared_handle_t h,
+                      const uint8_t* key, size_t klen,
+                      const uint8_t* val, size_t vlen,
+                      int val_type, double ttl_secs);
+  int  ngx_shared_add(ngx_shared_handle_t h,
+                      const uint8_t* key, size_t klen,
+                      const uint8_t* val, size_t vlen,
+                      int val_type, double ttl_secs);
+  int  ngx_shared_replace(ngx_shared_handle_t h,
+                          const uint8_t* key, size_t klen,
+                          const uint8_t* val, size_t vlen,
+                          int val_type, double ttl_secs);
+  int  ngx_shared_delete(ngx_shared_handle_t h,
+                         const uint8_t* key, size_t klen);
+
+  /* Numeric increment */
+  int  ngx_shared_incr(ngx_shared_handle_t h,
+                       const uint8_t* key, size_t klen,
+                       double delta, double init, int has_init,
+                       double ttl_secs, double* result);
+
+  /* TTL management */
+  int  ngx_shared_expire(ngx_shared_handle_t h,
+                         const uint8_t* key, size_t klen,
+                         double ttl_secs);
+  int  ngx_shared_ttl(ngx_shared_handle_t h,
+                      const uint8_t* key, size_t klen,
+                      double* out_ttl);
+
+  /* Bulk operations */
+  void ngx_shared_flush_all(ngx_shared_handle_t h);
+  int  ngx_shared_flush_expired(ngx_shared_handle_t h, int max);
+
+  /* Stats */
+  uint64_t ngx_shared_capacity(ngx_shared_handle_t h);
+  uint64_t ngx_shared_free_space(ngx_shared_handle_t h);
+]]
+```
+
+### Error codes
+
+| Code | Constant                | Meaning               |
+|------|-------------------------|-----------------------|
+| `0`  | `NGX_SHARED_OK`         | Success               |
+| `-1` | `NGX_SHARED_NOT_FOUND`  | Key not found         |
+| `-2` | `NGX_SHARED_ERR_EXISTS` | Key already exists    |
+| `-3` | `NGX_SHARED_ERR_NOMEM`  | Out of memory         |
+| `-4` | `NGX_SHARED_ERR_TYPE`   | Value type mismatch   |
+| `-5` | `NGX_SHARED_ERR_FULL`   | Hash table full       |
+| `-6` | `NGX_SHARED_ERR_INVAL`  | Invalid argument      |
+
+### Value types
+
+| Constant | Value | Storage format              |
+|----------|-------|-----------------------------|
+| bytes    | `0`   | Raw bytes                   |
+| f64      | `1`   | IEEE 754 double, LE         |
+| bool     | `2`   | Single byte (0 or 1)        |
+
+### Memory ownership
+
+`ngx_shared_get` heap-allocates a buffer for the returned value. The caller
+**must** free it with `ngx_shared_free_bytes(ptr, len)`. The Lua wrapper in
+`lnt_shared.lua` handles this automatically; standalone FFI users must call
+`free_bytes` themselves.
+
+### Symbol naming
+
+FFI symbols use the `ngx_shared_*` prefix (rather than `lnt_shared_*`). This
+is a legacy name retained for ABI compatibility after the rename from
+`ngx_shared` to `lnt_shared` in v0.4.3. The symbols are stable and will not
+change.
+
+### Minimal example (standalone FFI)
+
+```lua
+local ffi = require("ffi")
+ffi.cdef[[ /* paste cdef block above */ ]]
+local lib = ffi.load("./lunet/liblnt_shared.so")  -- or .dylib on macOS
+
+local h = lib.ngx_shared_open("my_dict", 65536)
+assert(h ~= nil)
+
+-- Set a string value
+local rc = lib.ngx_shared_set(h, "greeting", 8, "hello", 5, 0, 0)
+assert(rc == 0)
+
+-- Get it back
+local out_val = ffi.new("uint8_t*[1]")
+local out_len = ffi.new("size_t[1]")
+local out_type = ffi.new("int[1]")
+rc = lib.ngx_shared_get(h, "greeting", 8, out_val, out_len, out_type)
+assert(rc == 0)
+print(ffi.string(out_val[0], out_len[0]))  --> "hello"
+lib.ngx_shared_free_bytes(out_val[0], out_len[0])
+
+lib.ngx_shared_close(h)
+```
+
+---
+
+## jsonic — streaming JSON codec
+
+POSIX-only (Linux / macOS). Provides a streaming JSON decoder (with an
+Lua-side encoder).
+
+### FFI declarations
+
+```lua
+ffi.cdef[[
+  int  lunet_jsonic_decode(const uint8_t* json, size_t len,
+                           uint8_t** out, size_t* out_len);
+  void lunet_jsonic_free_bytes(uint8_t* p, size_t len);
+]]
+```
+
+### Error codes
+
+| Code | Constant              | Meaning           |
+|------|-----------------------|-------------------|
+| `0`  | `JSONIC_OK`           | Success           |
+| `-1` | `JSONIC_ERR_PARSE`    | Parse error       |
+| `-2` | `JSONIC_ERR_INVAL`    | Invalid argument  |
+
+### Binary wire format
+
+`lunet_jsonic_decode` returns a binary encoding (not JSON text). The Lua
+loader in `jsonic.lua` decodes this into Lua tables. Standalone FFI users
+who want decoded Lua values should use the Lua wrapper rather than calling
+the FFI directly — the binary format is internal to the codec pair.
+
+### Memory ownership
+
+Same as lnt_shared: `lunet_jsonic_decode` heap-allocates the output buffer;
+the caller must free it with `lunet_jsonic_free_bytes`.
+
+---
+
+## Database drivers
+
+The `.so`/`.dll` files in `lunet/` are loaded automatically by `require()`
+when the corresponding Lua module is first accessed. Transaction wrappers
+(`*_tx.lua`) are plain Lua modules that add `conn:begin()`, `conn:commit()`,
+and `conn:rollback()` methods to the native driver connections.
+
+---
+
+## Platform notes
+
+- **Linux (amd64 / arm64)**: All extensions are included. The archive is
+  built on Ubuntu 24.04 and links against system `glibc` and `openssl`.
+- **macOS (arm64)**: All extensions are included. The archive is built on
+  macOS 15+ and targets `macosx-version-min=14.0`.
+- **Windows (amd64)**: Rust extensions (`lnt_shared`, `jsonic`) are not
+  included because the underlying crates are POSIX-only. Database drivers
+  and transaction wrappers are shipped.


### PR DESCRIPTION
## Problem

The binary release archive (e.g., `lunet-macos.tar.gz`) ships `liblnt_shared.{so,dylib}`, `lnt_shared.lua`, `liblunet_jsonic.{so,dylib}`, `jsonic.lua`, and DB driver `.so`/`.dll` files with **no in-archive documentation** about what anything is or how to consume it.

A downstream user extracts the archive, sees a sea of binary files, and has no idea:
1. What each file is
2. How `lunet-run` auto-resolves extensions (it adds `<dir>/lunet/?.lua` to `package.path`, so `require("lunet.lnt_shared")` just works)
3. How to use the Rust extensions standalone via FFI (cdef declarations, error codes, value type constants, memory ownership semantics)

## Fix

Ship `docs/RELEASE-LAYOUT.md` and `docs/RELEASE-LAYOUT-CN.md` inside the binary release archives on all three platforms (Linux, macOS, Windows).

The doc covers:
- Archive directory layout with a table mapping each file to what it is
- Extension auto-resolution mechanism
- Complete standalone FFI API surface for **lnt_shared** (17 cdef functions, 7 error codes, 3 value types, memory ownership rules, minimal standalone example)
- Complete standalone FFI API surface for **jsonic** (2 cdef functions, 3 error codes, wire format note)
- Platform notes (Windows ships no Rust extensions because POSIX-only)

This is a documentation-only change — three `cp`/`Copy-Item` lines added in `.github/workflows/build.yml` packaging steps, no code changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lua-lunet/codesmith/lunet/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->