### PR TITLE
feat: per-release verified fetch helper lunet_fetch_release_<tag>.lua (#143)

### DIFF
--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -14,7 +14,10 @@
 
 ## Quick Start
 
+Fetch a verified, project-local runtime with the release fetcher (SHA-256 checked against the release metadata before extraction):
+
 ```bash
-tar -xzf lunet-linux-amd64.tar.gz
-./lunet-run path/to/app.lua
+curl -fsSLO https://github.com/lua-lunet/lunet/releases/download/@RELEASE_TAG@/lunet_fetch_release_@RELEASE_TAG@.lua
+lua lunet_fetch_release_@RELEASE_TAG@.lua   # installs into .lunet/@RELEASE_TAG@/
+.lunet/@RELEASE_TAG@/lunet-run path/to/app.lua
 ```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -827,6 +827,13 @@ jobs:
         xmake lua bin/generate_release_notes.lua
         cat release-notes.md
 
+    - name: Render fetch-release helper
+      env:
+        LUNET_RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref_name }}
+      run: |
+        sed "s/@RELEASE_TAG@/${LUNET_RELEASE_TAG}/g" bin/lunet_fetch_release.lua > "release-assets/lunet_fetch_release_${LUNET_RELEASE_TAG}.lua"
+        ! grep -q '@RELEASE_TAG@' "release-assets/lunet_fetch_release_${LUNET_RELEASE_TAG}.lua"
+
     - name: Create or update GitHub release
       uses: softprops/action-gh-release@v2
       with:
@@ -841,3 +848,4 @@ jobs:
           release-assets/lunet-linux-arm64-sdk.tar.gz
           release-assets/lunet-macos-sdk.tar.gz
           release-assets/lunet-windows-amd64-sdk.zip
+          release-assets/lunet_fetch_release_${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref_name }}.lua

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,11 @@ Before creating or announcing a release:
    - `lunet-linux-arm64-sdk.tar.gz`
    - `lunet-macos-sdk.tar.gz`
    - `lunet-windows-amd64-sdk.zip`
+   - plus `lunet_fetch_release_<tag>.lua`, rendered by the publish workflow from
+     `bin/lunet_fetch_release.lua` (the `@RELEASE_TAG@` placeholder becomes the
+     release tag). The fetcher installs the runtime into a project-local
+     `.lunet/<tag>/` with SHA-256 verification against the release metadata
+     (issue #143).
 3. **Readable release notes:** Notes must include at minimum:
    - `## Highlights`
    - `## Binaries`

--- a/bin/generate_release_notes.lua
+++ b/bin/generate_release_notes.lua
@@ -12,8 +12,10 @@
 --     else vX.Y.0 on GitHub, else the earliest published vX.Y.* release --
 --     then list the fixes in this patch range.
 --
--- The generated "## Highlights" is followed by the static sections from
--- .github/release-template.md (Binaries / Embeddable SDKs / Quick Start).
+-- The generated "## Highlights" is followed by the sections from
+-- .github/release-template.md (Binaries / Embeddable SDKs / Quick Start),
+-- with the @RELEASE_TAG@ placeholder substituted (same convention as
+-- bin/lunet_fetch_release.lua).
 --
 -- Runs under `xmake lua`. Requires git tags (fetch-depth: 0) and, for the
 -- patch path, the GitHub CLI with GH_TOKEN set.
@@ -232,6 +234,7 @@ end
 
 local highlights = compute_highlights()
 local static_body = io.readfile(path.join(".github", "release-template.md"))
+static_body = static_body:gsub("@RELEASE_TAG@", TAG)
 
 local notes = table.concat({ "## Highlights", "", highlights, "", static_body }, "\n")
 
@@ -239,7 +242,11 @@ local notes = table.concat({ "## Highlights", "", highlights, "", static_body },
 -- "{ }" when the chunk returns nothing, so stdout cannot be redirected into
 -- the release body (v0.5.0 shipped with that trailing "{ }"). The script
 -- writes the file itself; stdout is for the CI log only.
+--
+-- Do NOT use print() here: xmake's sandboxed print expands "$(shell ...)"
+-- sequences by executing them, so any notes content showing Makefile-style
+-- $(shell ...) examples aborts the whole run. io.stdout:write is raw.
 local out_path = os.getenv("LUNET_RELEASE_NOTES_OUT") or "release-notes.md"
 io.writefile(out_path, notes)
 io.stderr:write("[release-notes] wrote " .. out_path .. "\n")
-print(notes)
+io.stdout:write(notes, "\n")

--- a/bin/lunet_fetch_release.lua
+++ b/bin/lunet_fetch_release.lua
@@ -1,0 +1,294 @@
+#!/usr/bin/env lua
+-- lunet_fetch_release.lua -- fetch, verify and install an official lunet
+-- binary release into a project-local, versioned directory.
+--
+-- This file is a TEMPLATE: CI renders it per release as
+--   lunet_fetch_release_<tag>.lua
+-- by substituting @RELEASE_TAG@. Do not hand-edit rendered copies.
+--
+-- Result layout (relative to the current working directory):
+--   .lunet/<tag>/lunet-run     (lunet-run.exe on Windows)
+--   .lunet/<tag>/types/        (shipped LuaCATS + Teal documentation)
+--   ... remaining official archive contents preserved alongside.
+--
+-- Usage:
+--   lua lunet_fetch_release_<tag>.lua
+--   stdout (last line): the runtime path, e.g. .lunet/v0.7.2/lunet-run
+--   All progress/diagnostics go to stderr so Makefiles can capture stdout:
+--     LUNET_RUN := $(shell lua lunet_fetch_release_<tag>.lua)
+--
+-- Guarantees (per lua-lunet/lunet#143):
+--   * host OS/arch detection; fails clearly on unsupported hosts
+--   * downloads only from the official lua-lunet/lunet GitHub release
+--   * SHA-256 of the archive verified against the release metadata digest
+--     before extraction; fails closed on mismatch
+--   * atomic install: download/extract in a sibling staging dir, moved into
+--     place only after digest and layout checks pass
+--   * idempotent: a valid existing install is not downloaded again; an
+--     incomplete install is repaired
+--
+-- Host requirements: curl, a SHA-256 tool (shasum or sha256sum on Unix,
+-- certutil on Windows), tar (Windows 10+ ships bsdtar as tar.exe, which also
+-- reads .zip). Runs on Lua 5.1+ and LuaJIT.
+
+local RELEASE_TAG = "@RELEASE_TAG@"
+local REPO = "lua-lunet/lunet"
+
+local DEST = ".lunet/" .. RELEASE_TAG
+local STAGING = ".lunet/.staging-" .. RELEASE_TAG
+local IS_WINDOWS = os.getenv("OS") == "Windows_NT"
+local BINNAME = IS_WINDOWS and "lunet-run.exe" or "lunet-run"
+
+local function log(msg)
+	io.stderr:write("[lunet-fetch] " .. msg .. "\n")
+end
+
+local function die(msg)
+	log("ERROR: " .. msg)
+	os.exit(1)
+end
+
+-- Portable os.execute wrapper: true iff the command exited 0.
+-- 5.1/LuaJIT return a raw status number (0 == success); 5.2+ return
+-- true, "exit", 0 on success.
+local function run(cmd)
+	local ok, _, code = os.execute(cmd)
+	if ok == true then
+		return code == 0
+	end
+	if type(ok) == "number" then
+		return ok == 0
+	end
+	return false
+end
+
+local function capture(cmd)
+	local p = io.popen(cmd)
+	if not p then
+		return nil
+	end
+	local out = p:read("*a")
+	p:close()
+	return out
+end
+
+local function winpath(p)
+	return (p:gsub("/", "\\"))
+end
+
+local function file_exists(path)
+	local f = io.open(path, "r")
+	if f then
+		f:close()
+		return true
+	end
+	return false
+end
+
+local function mkdir_p(path)
+	if IS_WINDOWS then
+		run('if not exist "' .. winpath(path) .. '" mkdir "' .. winpath(path) .. '"')
+	else
+		run('mkdir -p "' .. path .. '"')
+	end
+end
+
+local function rm_rf(path)
+	if IS_WINDOWS then
+		run('if exist "' .. winpath(path) .. '" rmdir /s /q "' .. winpath(path) .. '"')
+	else
+		run('rm -rf "' .. path .. '"')
+	end
+end
+
+local function detect_asset()
+	if IS_WINDOWS then
+		local arch = os.getenv("PROCESSOR_ARCHITECTURE") or ""
+		if arch == "AMD64" then
+			return "lunet-windows-amd64.zip"
+		end
+		return nil, "unsupported Windows architecture: "
+			.. (arch ~= "" and arch or "unknown")
+			.. " (published: amd64)"
+	end
+	local uname_s = (capture("uname -s 2>/dev/null") or ""):gsub("%s+", "")
+	local uname_m = (capture("uname -m 2>/dev/null") or ""):gsub("%s+", "")
+	if uname_s == "Darwin" then
+		return "lunet-macos.tar.gz"
+	end
+	if uname_s == "Linux" then
+		if uname_m == "x86_64" or uname_m == "amd64" then
+			return "lunet-linux-amd64.tar.gz"
+		end
+		if uname_m == "aarch64" or uname_m == "arm64" then
+			return "lunet-linux-arm64.tar.gz"
+		end
+		return nil, "unsupported Linux architecture: " .. uname_m .. " (published: amd64, arm64)"
+	end
+	return nil, "unsupported host OS: " .. (uname_s ~= "" and uname_s or "unknown")
+end
+
+-- Expected SHA-256 for the asset, from the official release metadata.
+-- The GitHub API emits per-asset "digest":"sha256:<hex>" fields; we bound the
+-- search to the window between this asset's "name" and the end of its object
+-- ("browser_download_url", the last field) so a null/missing digest on our
+-- asset can never match a different asset's digest.
+local function fetch_expected_digest(asset)
+	local api = "https://api.github.com/repos/" .. REPO .. "/releases/tags/" .. RELEASE_TAG
+	local json = capture(
+		'curl -fsSL --connect-timeout 10 --max-time 30'
+			.. ' -H "Accept: application/vnd.github+json"'
+			.. ' -H "User-Agent: lunet-fetch-release"'
+			.. ' "' .. api .. '"'
+	)
+	if not json or json == "" then
+		die("could not query release metadata: " .. api)
+	end
+	local assets_start = json:find('"assets"%s*:%s*%[') or 1
+	local needle = '"name":"' .. asset .. '"'
+	local _, name_end = json:find(needle, assets_start, true)
+	if not name_end then
+		die("asset " .. asset .. " not found in release " .. RELEASE_TAG .. " metadata")
+	end
+	local window_end = json:find('"browser_download_url"', name_end, true) or #json
+	local window = json:sub(name_end, window_end)
+	local hex = window:match('"digest"%s*:%s*"sha256:([0-9a-fA-F]+)"')
+	if not hex then
+		die("no SHA-256 digest published for " .. asset .. " (failing closed)")
+	end
+	return hex:lower()
+end
+
+local function sha256_file(path)
+	if IS_WINDOWS then
+		local out = capture('certutil -hashfile "' .. winpath(path) .. '" SHA256')
+		if out then
+			local lines = {}
+			for l in out:gmatch("[^\r\n]+") do
+				lines[#lines + 1] = l
+			end
+			local hex = (lines[2] or ""):gsub("%s+", ""):lower()
+			if #hex == 64 and hex:match("^[0-9a-f]+$") then
+				return hex
+			end
+		end
+		return nil
+	end
+	if run("command -v shasum >/dev/null 2>&1") then
+		local out = capture('shasum -a 256 "' .. path .. '"')
+		return out and out:match("^([0-9a-f]+)")
+	end
+	if run("command -v sha256sum >/dev/null 2>&1") then
+		local out = capture('sha256sum "' .. path .. '"')
+		return out and out:match("^([0-9a-f]+)")
+	end
+	return nil
+end
+
+local function extract(archive, dest_dir)
+	if archive:match("%.zip$") then
+		if IS_WINDOWS then
+			if run('tar -xf "' .. winpath(archive) .. '" -C "' .. winpath(dest_dir) .. '"') then
+				return true
+			end
+			return run(
+				"powershell -NoProfile -Command \"Expand-Archive -LiteralPath '"
+					.. winpath(archive)
+					.. "' -DestinationPath '"
+					.. winpath(dest_dir)
+					.. "' -Force\""
+			)
+		end
+		return run('unzip -q "' .. archive .. '" -d "' .. dest_dir .. '"')
+	end
+	return run('tar -xzf "' .. archive .. '" -C "' .. dest_dir .. '"')
+end
+
+local function install_valid(dir)
+	return file_exists(dir .. "/" .. BINNAME)
+		and file_exists(dir .. "/types/lunet.lua")
+		and file_exists(dir .. "/.install-sha256")
+end
+
+local function main()
+	-- Idempotency: a valid matching install is reused without any network I/O.
+	if install_valid(DEST) then
+		log("valid existing installation at " .. DEST .. " (nothing to do)")
+		print(DEST .. "/" .. BINNAME)
+		return
+	end
+	if file_exists(DEST .. "/" .. BINNAME) or file_exists(DEST .. "/types/lunet.lua") then
+		log("incomplete installation at " .. DEST .. " (repairing)")
+	end
+
+	local asset, err = detect_asset()
+	if not asset then
+		die(err)
+	end
+	log("host asset: " .. asset)
+
+	if IS_WINDOWS then
+		if not run("where curl >NUL 2>&1") then
+			die("curl not found on PATH")
+		end
+	elseif not run("command -v curl >/dev/null 2>&1") then
+		die("curl not found on PATH")
+	end
+
+	local expected = fetch_expected_digest(asset)
+	log("expected sha256: " .. expected)
+
+	rm_rf(STAGING)
+	mkdir_p(STAGING)
+
+	local url = "https://github.com/" .. REPO .. "/releases/download/" .. RELEASE_TAG .. "/" .. asset
+	local dl = STAGING .. "/" .. asset
+	log("downloading " .. url)
+	if not run('curl -fsSL --connect-timeout 10 --max-time 600 -o "' .. dl .. '" "' .. url .. '"') then
+		rm_rf(STAGING)
+		die("download failed: " .. url)
+	end
+
+	local actual = sha256_file(dl)
+	if not actual then
+		rm_rf(STAGING)
+		die("no SHA-256 tool found (need shasum, sha256sum, or certutil)")
+	end
+	if actual ~= expected then
+		rm_rf(STAGING)
+		die("SHA-256 mismatch for " .. asset .. "\n  expected: " .. expected .. "\n  actual:   " .. actual)
+	end
+	log("digest verified")
+
+	if not extract(dl, STAGING) then
+		rm_rf(STAGING)
+		die("extraction failed for " .. asset)
+	end
+	if not file_exists(STAGING .. "/" .. BINNAME) or not file_exists(STAGING .. "/types/lunet.lua") then
+		rm_rf(STAGING)
+		die("archive layout check failed: expected " .. BINNAME .. " and types/ at top level")
+	end
+	-- The archive itself is not part of the installed layout.
+	os.remove(dl)
+	if not IS_WINDOWS then
+		run('chmod +x "' .. STAGING .. "/" .. BINNAME .. '"')
+	end
+
+	local marker = io.open(STAGING .. "/.install-sha256", "w")
+	if not marker then
+		rm_rf(STAGING)
+		die("could not write install marker in " .. STAGING)
+	end
+	marker:write(expected .. "\n")
+	marker:close()
+
+	rm_rf(DEST)
+	if not os.rename(STAGING, DEST) then
+		rm_rf(STAGING)
+		die("could not move " .. STAGING .. " into place at " .. DEST)
+	end
+	log("installed lunet " .. RELEASE_TAG .. " -> " .. DEST)
+	print(DEST .. "/" .. BINNAME)
+end
+
+main()

--- a/docs/release-notes/v0.7.3-CN.md
+++ b/docs/release-notes/v0.7.3-CN.md
@@ -1,0 +1,9 @@
+- **项目本地的可验证运行时安装**(#143):每个发布版本现在都会随归档文件附带一个自动生成的 `lunet_fetch_release_<tag>.lua` 辅助脚本。在使用方项目中用任意 Lua 5.1+ 解释器运行它,它会检测主机操作系统/架构,从本发布版本下载对应的官方二进制归档,并在解压*之前*根据发布元数据中的 digest 校验归档的 SHA-256(不匹配则直接失败),然后安装到按版本划分的项目本地目录:
+
+  ```text
+  .lunet/<tag>/lunet-run
+  .lunet/<tag>/types/
+  ```
+
+  安装是原子的(先在同级临时目录中暂存,只有 digest 和目录布局检查全部通过后才移动到位)且幂等的(有效的既有安装直接复用,不产生网络请求;不完整的安装会被修复)。进度信息输出到 stderr;stdout 的最后一行是运行时路径,因此 Makefile 可以锁定确切的运行时:`LUNET_RUN := $(shell lua lunet_fetch_release_<tag>.lua)` → `.lunet/<tag>/lunet-run path/to/app.lua`。不受支持的主机会明确报错,而不是回退到 `PATH` 上碰巧存在的某个 `lunet-run`。
+- **发布自动化**:辅助脚本由发布工作流按标签从 `bin/lunet_fetch_release.lua` 模板渲染生成,因此今后的每个发布版本都会自动携带名称正确、版本锁定正确的获取脚本,无需任何手动步骤。同样经过测试的 v0.7.2 脚本(`lunet_fetch_release_v0.7.2.lua`)已补充附加到 v0.7.2 发布版本中。

--- a/docs/release-notes/v0.7.3.md
+++ b/docs/release-notes/v0.7.3.md
@@ -1,0 +1,9 @@
+- **Project-local verified runtime installs** (#143): every release now ships a generated `lunet_fetch_release_<tag>.lua` helper alongside the archives. Run it from a consumer project with any Lua 5.1+ interpreter and it detects the host OS/architecture, downloads the matching official binary archive from this release, verifies the archive's SHA-256 against the release metadata digest *before* extraction (failing closed on mismatch), and installs into a versioned project-local layout:
+
+  ```text
+  .lunet/<tag>/lunet-run
+  .lunet/<tag>/types/
+  ```
+
+  Installs are atomic (staged in a sibling directory, moved into place only after digest and layout checks pass) and idempotent (a valid existing install is reused without network I/O; an incomplete one is repaired). Progress goes to stderr; stdout's last line is the runtime path, so a Makefile can pin the exact runtime: `LUNET_RUN := $(shell lua lunet_fetch_release_<tag>.lua)` → `.lunet/<tag>/lunet-run path/to/app.lua`. Unsupported hosts fail clearly rather than falling back to whatever `lunet-run` is on `PATH`.
+- **Release automation**: the helper is rendered per tag by the publish workflow from the `bin/lunet_fetch_release.lua` template, so every future release carries a correctly named, correctly pinned fetcher with no manual step. The same tested script for v0.7.2 (`lunet_fetch_release_v0.7.2.lua`) has been retroactively attached to the v0.7.2 release.


### PR DESCRIPTION
Implements lua-lunet/lunet#143.

## What

- `bin/lunet_fetch_release.lua`: Lua 5.1 template for the release fetcher. Detects host OS/arch, downloads the matching official non-SDK archive from the GitHub release, verifies SHA-256 against the release metadata `digest` before extraction (fails closed), stages in a sibling dir and atomically finalizes into `.lunet/<tag>/` (layout: `lunet-run` + `types/` + remaining archive files), idempotent with repair of incomplete installs, prints the runtime path on stdout (all progress on stderr) for Makefile capture.
- `.github/workflows/build.yml`: publish-release job now renders `lunet_fetch_release_<tag>.lua` from the template (sed substitution of `@RELEASE_TAG@`, with a guard that no placeholder remains) and attaches it to the release alongside the 8 archives.
- `docs/release-notes/v0.7.3.md` + `-CN.md`: curated highlights for v0.7.3.
- `AGENTS.md`: release gate asset list now includes the fetch helper.

## Testing

Rendered `lunet_fetch_release_v0.7.2.lua` and exercised it against the real v0.7.2 assets on macOS:

- fresh install: downloads, verifies digest (`125d9e30...` matches release metadata), installs exact layout, binary runs (`lunet ok: Lua 5.1`)
- idempotent re-run: no network I/O, prints path
- repair: `types/` removed -> detected incomplete -> re-downloaded, verified, restored
- workflow render step simulated byte-for-byte locally (sed + guard + luajit syntax check)

The tested v0.7.2 copy is already attached to the v0.7.2 release. The workflow automation itself will be exercised for the first time by the v0.7.3 tag build (deliberately untested locally — full release dry-runs are too slow; per release policy the tag-triggered CI is the test).

## Gate

Local parity gate green: `xmake lint`, `xmake check`, `xmake check-types`, `make test` (4/0/0/0), `xmake build-release`. ASan legs of `xmake preflight-easy-memory` remain env-blocked on macOS 26 per AGENTS.md; CI covers them.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lua-lunet/codesmith/lunet/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->